### PR TITLE
docs(spark-sql): add DROP TABLE reference page

### DIFF
--- a/docs/reference/spark-sql/ddl/drop-table.mdx
+++ b/docs/reference/spark-sql/ddl/drop-table.mdx
@@ -1,12 +1,62 @@
 ---
 title: Drop Table
-description: This documentation explains how to drop schema or properties of table from file system on Apache Spark SQL
+sidebar_label: Drop Table
+description: "DROP TABLE syntax reference for Spark SQL. Covers IF EXISTS, PURGE, qualified identifiers, and external table behavior with examples."
 slug: /reference/spark-sql/drop-table
 last_update:
-  date: 10/04/2022
-  author: Vugar Dadalov
+  date: 04/14/2026
+  author: Mateus Aubin
 ---
 
-The `DROP TABLE` statement delete the schema or properties of a table.
+`DROP TABLE` removes a table's catalog entry. By default, the data files, metadata files, and manifest lists stay in storage. Add `PURGE` to delete those files along with the catalog reference. For external tables, only the catalog entry is ever removed, regardless of `PURGE`.
+
+Spark SQL extends standard SQL with `IF EXISTS` for idempotent scripts. For the full upstream specification, see the [Spark SQL DROP TABLE reference](https://archive.apache.org/dist/spark/docs/3.5.5/sql-ref-syntax-ddl-drop-table.html).
 
 ---
+
+## Syntax
+
+```sql
+DROP TABLE [ IF EXISTS ] table_identifier [ PURGE ]
+```
+
+## Parameters
+
+- **`IF EXISTS`**: Suppresses the error if the table doesn't exist, so your script won't fail on a missing table.
+- **`table_identifier`**: The table to drop, written as `[database_name.]table_name` or as a three-part identifier `` `catalog_name`.`database_name`.`table_name` ``. Escape each part with backticks. Include the database or catalog prefix to target a table outside your current session context.
+- **`PURGE`**: Deletes the underlying data and metadata files from storage along with the catalog reference. Without this option, files remain in the storage layer.
+
+## Examples
+
+Here are the most common ways you'll use `DROP TABLE`.
+
+```sql
+-- Basic drop: removes catalog entry
+DROP TABLE employees;
+
+-- Safe drop: no error if the table does not exist
+DROP TABLE IF EXISTS employees;
+
+-- PURGE: drops the catalog reference and deletes all data and metadata
+-- files from storage; without PURGE the files remain in your object store
+DROP TABLE employees PURGE;
+
+-- Qualified identifier: target a table in a specific database
+DROP TABLE IF EXISTS staging_db.raw_events;
+
+-- Three-part identifier: target a table in a specific catalog and database
+DROP TABLE IF EXISTS `my_catalog`.`staging_db`.`raw_events`;
+
+-- External table: only the catalog entry is removed;
+-- data files at the LOCATION path are NOT deleted
+CREATE TABLE ext_logs (event STRING, ts TIMESTAMP)
+USING parquet
+LOCATION 's3://bucket/logs/';
+
+DROP TABLE ext_logs;
+```
+
+## Related Statements
+
+- [Create Table](./create-table.mdx): defines the tables that `DROP TABLE` removes.
+- [Drop Database](./drop-database.mdx): works the same way at the database level. The `CASCADE` option drops all tables in the database.

--- a/sidebars.js
+++ b/sidebars.js
@@ -154,7 +154,7 @@ const sidebars = {
             "reference/spark-sql/ddl/drop-database",
             "reference/spark-sql/ddl/create-table",
             "reference/spark-sql/ddl/alter-table",
-            // 'reference/spark-sql/ddl/drop-table',
+            "reference/spark-sql/ddl/drop-table",
             "reference/spark-sql/ddl/create-view",
             // "reference/spark-sql/ddl/sql-ddl-examples",
             // 'reference/spark-sql/ddl/drop-view'


### PR DESCRIPTION
## Summary

Adds the `DROP TABLE` reference page with syntax, parameters, and examples. Enables the previously commented-out sidebar entry.

## Testing

Verify locally with:

```bash
npm run start
```

Navigate to the DROP TABLE page under the Spark SQL DDL reference section.

<img width="1073" height="1276" alt="image" src="https://github.com/user-attachments/assets/b93ac13d-4449-44b3-9f16-a9e1692c1bdc" />

## References

- [CE-291: Write DDL Reference: drop-table.mdx](https://linear.app/iomete/issue/CE-291/write-ddl-reference-drop-tablemdx)