### PR TITLE
Replace reggionick/s3-deploy with AWS CLI for reliable S3 sync

### DIFF
--- a/.github/workflows/deployment_v3.yaml
+++ b/.github/workflows/deployment_v3.yaml
@@ -6,9 +6,6 @@ jobs:
   production:
     name: documentation-deployment-v3
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -20,18 +17,22 @@ jobs:
           cache: "yarn"
       - run: yarn install --no-progress --frozen-lockfile
       - run: yarn build
-      #https://github.com/Reggionick/s3-deploy
-      #https://stackoverflow.com/questions/18774069/amazon-cloudfront-cache-control-no-cache-header-has-no-effect-after-24-hours
-      - name: S3 Upload
-        uses: reggionick/s3-deploy@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          folder: build
-          bucket: ${{ secrets.s3_bucket_name }}/resources
-          bucket-region: ${{ secrets.s3_bucket_region }}
-          dist-id: ${{ secrets.cloudfront_distribution_id }}
-          invalidation: /resources*
-          delete-removed: true
-          no-cache: false
-          cache: 86400
-          private: true
-          filesToInclude: "**"
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.s3_bucket_region }}
+
+      - name: S3 Sync
+        run: |
+          aws s3 sync build/ s3://${{ secrets.s3_bucket_name }}/resources \
+            --delete \
+            --cache-control "max-age=86400"
+
+      - name: CloudFront Invalidation
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.cloudfront_distribution_id }} \
+            --paths "/resources/*"


### PR DESCRIPTION
### Summary
Replaces `reggionick/s3-deploy@v3` with native AWS CLI commands for S3 sync and CloudFront invalidation. Fixes stale files (e.g. `spark-connect/index.html`) persisting on S3 after deletion from the repo.

### Context
`reggionick/s3-deploy@v3` has three major bugs: `delete-removed: true` silently fails when the bucket path includes a subfolder (`bucket-name/resources`), the delete call is fire-and-forget so the process exits before deletes complete, and the underlying npm package is abandoned with no upstream fixes. The combination meant deleted docs pages were never removed from the S3 origin.

### Implementation
- Credentials moved from env-level secrets to `aws-actions/configure-aws-credentials@v4`, which is the current AWS-recommended approach and scopes auth to the step
- `aws s3 sync build/ s3://<bucket>/resources --delete` replaces the action; subfolder path is handled natively and `--delete` is synchronous
- CloudFront invalidation split into a discrete step using `aws cloudfront create-invalidation` with `/resources/*` path
- `--cache-control "max-age=86400"` preserves the prior 24-hour cache TTL