### PR TITLE
Clarify SQLAlchemy driver docs for non-default catalogs

### DIFF
--- a/user-guide/driver/sql-alchemy-driver.md
+++ b/user-guide/driver/sql-alchemy-driver.md
@@ -1,12 +1,12 @@
 ---
 title: SQLAlchemy Driver
-description: IOMETE lakehouse endpoints are compatible with special driver, you can use the samples repository to quick start
+description: IOMETE lakehouse endpoints are compatible with the py-hive-iomete driver, and you can use the samples repository for a quick start
 last_update:
   date: 10/04/2023
   author: Vusal Dadalov
 ---
 
-IOMETE lakehouse endpoints are compatible with [py-hive-iomete](https://pypi.org/project/py-hive-iomete) driver
+IOMETE lakehouse endpoints are compatible with the [py-hive-iomete](https://pypi.org/project/py-hive-iomete) driver.
 
 ## Usage
 
@@ -33,7 +33,7 @@ connection = hive.connect(
     scheme="<https or http>",
     data_plane="<data_plane_name>", # Optional, skip if using default data-plane
     lakehouse="<lakehouse_cluster_name>",
-    database="default",
+    database="default",  # For tables in a non-default catalog, use "<catalog>.<database>"
     username="<username>",
     password="<personal_access_token>"
 )
@@ -57,7 +57,7 @@ connection = hive.connect(
     scheme="<https or http>",
     data_plane="<data_plane_name>", # Optional, skip if using default data-plane
     lakehouse="<lakehouse_cluster_name>",
-    database="default",
+    database="default",  # For tables in a non-default catalog, use "<catalog>.<database>"
     username="<username>",
     password="<personal_access_token>"
 )
@@ -90,11 +90,11 @@ pip install "py-hive-iomete[sqlalchemy]"
 ```
 
 ```python
+from sqlalchemy import MetaData, Table
 from sqlalchemy.engine import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.schema import *
 
-# Possible dialects (hive and iomete are both operate identically):
+# Possible dialects (hive and iomete operate identically):
 # hive+http
 # hive+https
 # iomete+http
@@ -107,11 +107,24 @@ engine = create_engine(
 # engine = create_engine(
 #     'iomete+https://<username>:<personal_access_token>@<host>:<port>/<database>?lakehouse=<lakehouse_cluster_name>')
 
+# If your table is in a non-default catalog, specify the path as <catalog>.<database>.
+# Example:
+# iomete+https://<username>:<personal_access_token>@<host>:<port>/<catalog>.<database>?data_plane=<data_plane_name>&lakehouse=<lakehouse_cluster_name>
+
 session = sessionmaker(bind=engine)()
-records = session.query(Table('my_awesome_data', MetaData(bind=engine), autoload=True)) \
+records = session.query(Table(
+    "my_awesome_data",
+    MetaData(),
+    # schema="<database>",  # Optional: use when the table belongs to a different database than the one in the connection URL
+    autoload_with=engine,
+)) \
     .limit(10) \
     .all()
 print(records)
 ```
 
-You can find the configuration parameters from the lakehouse "Connection Details" tab from the IOMETE console
+You can find the configuration parameters in the lakehouse "Connection Details" tab in the IOMETE console.
+
+If your table is in a non-default catalog, use `<catalog>.<database>` in the connection URL path instead of only `<database>`.
+
+If the reflected table belongs to a different database than the one used in the connection URL, specify it with `schema="<database>"` in `Table(...)`.

--- a/user-guide/driver/sql-alchemy-driver.md
+++ b/user-guide/driver/sql-alchemy-driver.md
@@ -6,7 +6,7 @@ last_update:
   author: Vusal Dadalov
 ---
 
-IOMETE lakehouse endpoints are compatible with the [py-hive-iomete](https://pypi.org/project/py-hive-iomete) driver.
+IOMETE compute endpoints are compatible with the [py-hive-iomete](https://pypi.org/project/py-hive-iomete) driver.
 
 ## Usage
 
@@ -107,23 +107,53 @@ engine = create_engine(
 # engine = create_engine(
 #     'iomete+https://<username>:<personal_access_token>@<host>:<port>/<database>?lakehouse=<lakehouse_cluster_name>')
 
+session = sessionmaker(bind=engine)()
+records = (
+    session.query(
+        Table(
+            "my_awesome_data",
+            MetaData(),
+            autoload_with=engine,
+        )
+    )
+    .limit(10)
+    .all()
+)
+print(records)
+
 # If your table is in a non-default catalog, specify the path as <catalog>.<database>.
 # Example:
 # iomete+https://<username>:<personal_access_token>@<host>:<port>/<catalog>.<database>?data_plane=<data_plane_name>&lakehouse=<lakehouse_cluster_name>
 
+# Example: use a non-default catalog in the connection URL and specify
+# schema="<database_b>" when the reflected table belongs to a different
+# database than the one used in the connection URL.
+#
+# In this example, <database_a> is the database used in the connection URL,
+# and <database_b> is the database that contains the reflected table.
+# Both belong to the same <catalog>.
+
+engine = create_engine(
+    "iomete+https://<username>:<personal_access_token>@<host>:<port>/<catalog>.<database_a>?data_plane=<data_plane_name>&lakehouse=<lakehouse_cluster_name>"
+)
+
 session = sessionmaker(bind=engine)()
-records = session.query(Table(
-    "my_awesome_data",
-    MetaData(),
-    # schema="<database>",  # Optional: use when the table belongs to a different database than the one in the connection URL
-    autoload_with=engine,
-)) \
-    .limit(10) \
+records = (
+    session.query(
+        Table(
+            "my_awesome_data",
+            MetaData(),
+            schema="<database_b>",
+            autoload_with=engine,
+        )
+    )
+    .limit(10)
     .all()
+)
 print(records)
 ```
 
-You can find the configuration parameters in the lakehouse "Connection Details" tab in the IOMETE console.
+You can find the connection parameters in the compute "Connections" tab in the IOMETE console.
 
 If your table is in a non-default catalog, use `<catalog>.<database>` in the connection URL path instead of only `<database>`.
 

--- a/user-guide/driver/sql-alchemy-driver.md
+++ b/user-guide/driver/sql-alchemy-driver.md
@@ -11,7 +11,7 @@ IOMETE compute endpoints are compatible with the [py-hive-iomete](https://pypi.o
 ## Usage
 
 :::info
-For a quick start, you can use the samples repository: https://github.com/iomete/py-hive-iomete-samples
+For additional DB-API and SQLAlchemy reference examples, see: https://github.com/iomete/iomete-integrations/tree/main/py-hive-iomete
 :::
 
 ## DB-API


### PR DESCRIPTION
This updates the SQLAlchemy driver docs to clarify how to connect to tables in non-default catalogs.

Changes:
- modernized the SQLAlchemy reflection example to use `autoload_with=engine`
- added guidance for using `<catalog>.<database>` in the connection URL path
- added note about optional `schema="<database>"` when the reflected table belongs to a different database than the one used in the connection URL
- added the same non-default catalog note to the DB-API examples