### PR TITLE
docs: add IOMETE SQLAlchemy driver guide (Arrow Flight SQL)

### DIFF
--- a/sidebarsUserGuide.js
+++ b/sidebarsUserGuide.js
@@ -244,6 +244,7 @@ const sidebars = {
       label: "Client & Libraries",
       collapsed: true,
       items: [
+        "driver/iomete-sqlalchemy",
         "driver/sql-alchemy-driver",
         "driver/jdbc-driver",
         "driver/arrow-flight-jdbc-driver",

--- a/user-guide/driver/iomete-sqlalchemy.md
+++ b/user-guide/driver/iomete-sqlalchemy.md
@@ -1,0 +1,124 @@
+---
+title: IOMETE SQLAlchemy Driver
+description: Connect to IOMETE using the iomete-sqlalchemy dialect, which uses Arrow Flight SQL for high-performance gRPC-based connectivity.
+sidebar_label: IOMETE SQLAlchemy
+last_update:
+  date: 04/17/2026
+  author: Sanan Ahmadli
+---
+
+import Img from '@site/src/components/Img';
+
+The `iomete-sqlalchemy` package provides a SQLAlchemy dialect for IOMETE that communicates over [Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) (`adbc-driver-flightsql`) — offering faster, binary-efficient transport compared to the legacy Thrift/Hive driver.
+
+## Requirements
+
+- Python 3.9+
+- SQLAlchemy >= 2.0.30
+- adbc-driver-flightsql >= 1.1.0
+- pyarrow >= 16.0
+
+## Installation
+
+```bash
+pip install iomete-sqlalchemy
+```
+
+## Connection URL Format
+
+```
+iomete://<user>:<password>@<host>:<port>/<catalog>/<schema>?cluster=<cluster>&data_plane=<data_plane>
+```
+
+### Parameters
+
+| Parameter | Description | Default |
+|---|---|---|
+| `host` | IOMETE host | Required |
+| `port` | gRPC port | `443` |
+| `catalog` | Top-level catalog (e.g. `spark_catalog`) | Required |
+| `schema` | Schema / database inside the catalog | Required |
+| `cluster` | IOMETE compute cluster name | Required |
+| `data_plane` | IOMETE data plane name | Required |
+| `tls` | Use `grpc+tls` transport | `true` |
+| `max_msg_size` | Max gRPC message size in bytes | `134217728` (128 MB) |
+
+You can find the host, port, cluster, and data plane values from the **Connection Details** tab of your lakehouse in the IOMETE console.
+
+## Usage
+
+### Basic Connection
+
+```python
+from sqlalchemy import create_engine, text
+
+engine = create_engine(
+    "iomete://<username>:<personal_access_token>@<host>:443"
+    "/spark_catalog/default"
+    "?cluster=<cluster>&data_plane=<data_plane>"
+)
+
+with engine.connect() as conn:
+    result = conn.execute(text("SELECT 1")).scalar()
+    print(result)  # 1
+```
+
+### Querying Data
+
+```python
+from sqlalchemy import create_engine, text
+
+engine = create_engine(
+    "iomete://<username>:<personal_access_token>@<host>:443"
+    "/spark_catalog/default"
+    "?cluster=<cluster>&data_plane=<data_plane>"
+)
+
+with engine.connect() as conn:
+    rows = conn.execute(text("SELECT * FROM my_table LIMIT 10")).fetchall()
+    for row in rows:
+        print(row)
+```
+
+### Schema Inspection
+
+All reflection methods are fully implemented, making `iomete-sqlalchemy` compatible with schema inspection tools and data catalog integrations.
+
+```python
+from sqlalchemy import create_engine, inspect
+
+engine = create_engine(
+    "iomete://<username>:<personal_access_token>@<host>:443"
+    "/spark_catalog/default"
+    "?cluster=<cluster>&data_plane=<data_plane>"
+)
+
+inspector = inspect(engine)
+
+print(inspector.get_schema_names())
+print(inspector.get_table_names(schema="spark_catalog.default"))
+```
+
+## Supported Type Mappings
+
+| Spark / Iceberg type | SQLAlchemy type |
+|---|---|
+| `boolean` | `Boolean` |
+| `tinyint`, `smallint` | `SmallInteger` |
+| `int`, `integer` | `Integer` |
+| `bigint` | `BigInteger` |
+| `float`, `real` | `Float(24)` |
+| `double` | `Float(53)` |
+| `decimal(p, s)` | `Numeric(p, s)` |
+| `char(n)` | `CHAR(n)` |
+| `varchar(n)` | `VARCHAR(n)` |
+| `string`, `text` | `Text` |
+| `binary` | `LargeBinary` |
+| `date` | `Date` |
+| `timestamp`, `timestamp_ntz` | `DateTime` |
+| `array<…>`, `map<…>`, `struct<…>` | `JSON` |
+
+## Resources
+
+- [PyPI — iomete-sqlalchemy](https://pypi.org/project/iomete-sqlalchemy/)
+- [GitHub — iomete/iomete-sqlalchemy](https://github.com/iomete/iomete-sqlalchemy)


### PR DESCRIPTION
## Summary

- Adds `user-guide/driver/iomete-sqlalchemy.md` — a new guide for the [`iomete-sqlalchemy`](https://pypi.org/project/iomete-sqlalchemy/) package
- This driver uses Arrow Flight SQL (`adbc-driver-flightsql`) instead of the legacy Thrift/Hive driver (`py-hive-iomete`)
- Covers installation, connection URL format + parameters, usage examples (basic connection, querying, schema inspection), and Spark/Iceberg → SQLAlchemy type mappings
- Registers the new page in `sidebarsUserGuide.js` under **Client & Libraries**

## Test plan

- [ ] Navigate to User Guide → Client & Libraries → IOMETE SQLAlchemy in the dev server and verify the page renders correctly
- [ ] Confirm the legacy SQLAlchemy Driver page is still present alongside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)