### PR TITLE
Spark job creation doc update

### DIFF
--- a/blog/2022-09-21-new-features.md
+++ b/blog/2022-09-21-new-features.md
@@ -44,7 +44,7 @@ Simply manage IOMETE permissions through the Access Control System. Detailed rol
 
 ## Improved dashboard
 
-The improved dashboard makes it easy to analyze your tasks and discover pain points. With the Grafana tool one can easily optimize [spark jobs](/user-guide/spark-jobs/getting-started).
+The improved dashboard makes it easy to analyze your tasks and discover pain points. With the Grafana tool one can easily optimize [spark jobs](/user-guide/spark-jobs/creating-spark-job).
 
 ![IOMETE dashboard](/img/blog/2022-09-21-new-features/improved-dashboard.jpeg)
 

--- a/blog/2025-02-24-platform-components-and-enterprise-architecture.md
+++ b/blog/2025-02-24-platform-components-and-enterprise-architecture.md
@@ -55,7 +55,7 @@ Database Navigator functionality provides intuitive access to the entire data ec
 
 ## **ETL Framework**
 
-The platform's ETL capabilities address the complex data integration requirements of modern enterprises. Through sophisticated [Spark job](/user-guide/spark-jobs/getting-started) management and [orchestration](/glossary/orchestration) capabilities, organizations can implement complex [data pipelines](/glossary/data-pipelines) while maintaining operational efficiency.
+The platform's ETL capabilities address the complex data integration requirements of modern enterprises. Through sophisticated [Spark job](/user-guide/spark-jobs/creating-spark-job) management and [orchestration](/glossary/orchestration) capabilities, organizations can implement complex [data pipelines](/glossary/data-pipelines) while maintaining operational efficiency.
 
 <Img src="/img/blog/2025-02-24-platform-components-and-enterprise-architecture/etl-framework.png" alt="" maxWidth="500px" centered borderless/>
 

--- a/blog/2025-06-30-key-tools-kubernetes-native-data-stack.md
+++ b/blog/2025-06-30-key-tools-kubernetes-native-data-stack.md
@@ -30,7 +30,7 @@ The success of Kubernetes-native deployment in data engineering depends heavily 
 
 **How IOMETE fits in:**
 
-IOMETE integrates seamlessly with Airflow through its SQL endpoints and [Spark job](/user-guide/spark-jobs/getting-started) APIs. Spark jobs triggered in Airflow can target IOMETE compute clusters, using [Spark Connect](/blog/spark-connect-tutorial) or [Apache Arrow](/blog/apache-arrow-format) Flight for fast transport. Workload monitoring and job history are available in IOMETE’s UI, while Airflow retains orchestration logic.
+IOMETE integrates seamlessly with Airflow through its SQL endpoints and [Spark job](/user-guide/spark-jobs/creating-spark-job) APIs. Spark jobs triggered in Airflow can target IOMETE compute clusters, using [Spark Connect](/blog/spark-connect-tutorial) or [Apache Arrow](/blog/apache-arrow-format) Flight for fast transport. Workload monitoring and job history are available in IOMETE’s UI, while Airflow retains orchestration logic.
 
 **YAML snippet:**
 

--- a/blog/2025-09-20-data-platform-security.md
+++ b/blog/2025-09-20-data-platform-security.md
@@ -19,7 +19,7 @@ Resource Access Management (RAS) represents a sophisticated approach to authoriz
 
 ## The Challenge of Modern Data Platform Authorization
 
-Modern [data platforms](https://iomete.com/product/data-platform/platform-overview) like IOMETE encompass a diverse ecosystem of resources: compute instances that process data, [Spark jobs](/user-guide/spark-jobs/getting-started) that execute analytics workflows, secrets that store sensitive configuration data, worksheets for collaborative analysis, and countless other assets. Each of these resource types has unique characteristics, usage patterns, and security requirements.
+Modern [data platforms](https://iomete.com/product/data-platform/platform-overview) like IOMETE encompass a diverse ecosystem of resources: compute instances that process data, [Spark jobs](/user-guide/spark-jobs/creating-spark-job) that execute analytics workflows, secrets that store sensitive configuration data, worksheets for collaborative analysis, and countless other assets. Each of these resource types has unique characteristics, usage patterns, and security requirements.
 
 Traditional authorization approaches often fall short because they:
 

--- a/blog/2025-11-10-job-orchestrator-end-to-end-design-journey.md
+++ b/blog/2025-11-10-job-orchestrator-end-to-end-design-journey.md
@@ -26,7 +26,7 @@ Our starting point was the [Spark Operator](https://github.com/kubeflow/spark-op
 
 The process looked simple:
 
-1. User created a [Spark job](/user-guide/spark-jobs/getting-started) request via the IOMETE console.
+1. User created a [Spark job](/user-guide/spark-jobs/creating-spark-job) request via the IOMETE console.
 2. Backend generated the YAML spec and pushed it to Kubernetes.
 3. The Spark Operator picked it up and executed it.
 
@@ -206,4 +206,4 @@ The final Job Orchestrator design combines:
 
 We started with simple solutions (API-based capacity checks, Prefect for orchestration) and avoided over-engineering. The result is a system that not only works today, but also leaves room for future growth — DLQs, preemption, multi-job support, and cost intelligence.
 
-👉 Want to dive deeper on Spark Jobs in IOMETE: [Spark Jobs Guide](/user-guide/spark-jobs/getting-started)
+👉 Want to dive deeper on Spark Jobs in IOMETE: [Spark Jobs Guide](/user-guide/spark-jobs/creating-spark-job)

--- a/blog/2026-01-27-scaling-machine-learning-iomete-lakehouse.md
+++ b/blog/2026-01-27-scaling-machine-learning-iomete-lakehouse.md
@@ -111,7 +111,7 @@ We've made deployment as simple as possible. The repository includes a pre-confi
 
 ### Two Ways to Deploy {#two-ways-to-deploy}
 
-See details in the [IOMETE Developer Guide](/user-guide/spark-jobs/getting-started) on how to submit a [Spark job](/user-guide/spark-jobs/getting-started). Running ML training process is just submitting another Spark job. Note that here you have two options for "_Main application file_":
+See details in the [IOMETE Developer Guide](/user-guide/spark-jobs/creating-spark-job) on how to submit a [Spark job](/user-guide/spark-jobs/creating-spark-job). Running ML training process is just submitting another Spark job. Note that here you have two options for "_Main application file_":
 
 1. **The Container Way:** Set it to `local:///app/job.py`. The code is "baked" into your Docker image.
 
@@ -159,5 +159,5 @@ Once finished, the logs will print various cost/loss metrics. Because Spark's Ra
 ### Ready to Scale? {#ready-to-scale}
 
 1. Clone the [IOMETE ML Quickstart Repo](https://github.com/iomete/iomete-ml-quickstart).
-2. Follow the [IOMETE Developer Guide](/user-guide/spark-jobs/getting-started) to submit your first job.
+2. Follow the [IOMETE Developer Guide](/user-guide/spark-jobs/creating-spark-job) to submit your first job.
 3. Watch the Spark UI, and witness the power of distributed ML!

--- a/docs/community-deployment/aws/install.md
+++ b/docs/community-deployment/aws/install.md
@@ -234,7 +234,7 @@ Read our guide on how to sync data from JDBC sources, like MySQL, PostgreSQL, an
 If you have data files in AWS S3, you can directly query them using the S3 connector.
 </Card>
 
-<Card title="Getting Started with Spark Jobs" icon={<Sparkle />} link="user-guide/spark-jobs/getting-started">
+<Card title="Getting Started with Spark Jobs" icon={<Sparkle />} link="user-guide/spark-jobs/creating-spark-job">
 Learn how to run Spark jobs on IOMETE.
 </Card>
 

--- a/docs/community-deployment/gcp/install.md
+++ b/docs/community-deployment/gcp/install.md
@@ -212,7 +212,7 @@ Start using IOMETE with the following guides
 Read our guide on how to sync data from JDBC sources, like MySQL, PostgreSQL, and Oracle.
 </Card>
 
-<Card title="Getting Started with Spark Jobs" icon={<Sparkle />} link="user-guide/spark-jobs/getting-started">
+<Card title="Getting Started with Spark Jobs" icon={<Sparkle />} link="user-guide/spark-jobs/creating-spark-job">
 Learn how to run Spark jobs on IOMETE.
 </Card>
 

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -51,7 +51,7 @@ The Core Service owns platform-wide settings and cross-cutting concerns:
 This is the largest service by API surface because it manages every Spark-based resource:
 
 - [Compute clusters](/user-guide/compute-clusters/overview): create, start, stop, delete
-- [Spark batch and streaming jobs](/user-guide/spark-jobs/getting-started): submission, monitoring, scheduling
+- [Spark batch and streaming jobs](/user-guide/spark-jobs/creating-spark-job): submission, monitoring, scheduling
 - [Jupyter containers](/user-guide/notebook/jupyter-containers): lifecycle management
 - [Docker registries](/user-guide/private-docker-registry) and image management
 - Namespace and [secrets](/user-guide/secrets) management
@@ -132,7 +132,7 @@ See [Compute Clusters](/user-guide/compute-clusters/overview) for details.
 
 ### Spark Jobs
 
-Batch and streaming Spark applications. You can submit Scala or PySpark jobs, schedule them with the [Job Orchestrator](/user-guide/spark-jobs/job-orchestrator), and monitor execution through the console. See [Spark Jobs](/user-guide/spark-jobs/getting-started).
+Batch and streaming Spark applications. You can submit Scala or PySpark jobs, schedule them with the [Job Orchestrator](/user-guide/spark-jobs/job-orchestrator), and monitor execution through the console. See [Spark Jobs](/user-guide/spark-jobs/creating-spark-job).
 
 ### Jupyter Containers
 

--- a/docs/getting-started/platform-tour.md
+++ b/docs/getting-started/platform-tour.md
@@ -93,7 +93,7 @@ This page charts every Spark application run with interactive visualizations. Fi
 
 <Img src="/img/getting-started/platform-tour/spark-applications.png" alt="Spark Applications page" maxWidth="900px"/>
 
-More in the [Spark Jobs](/user-guide/spark-jobs/getting-started) guide.
+More in the [Spark Jobs](/user-guide/spark-jobs/creating-spark-job) guide.
 
 ### Streaming Jobs
 
@@ -107,7 +107,7 @@ Job Templates define reusable Spark job configurations. Browse the built-in mark
 
 <Img src="/img/getting-started/platform-tour/job-templates.png" alt="Job Templates page"/>
 
-The [Getting Started with Spark Jobs](/user-guide/spark-jobs/getting-started) guide has a full walkthrough.
+The [Getting Started with Spark Jobs](/user-guide/spark-jobs/creating-spark-job) guide has a full walkthrough.
 
 ## Governance
 

--- a/docs/getting-started/scalability.md
+++ b/docs/getting-started/scalability.md
@@ -80,7 +80,7 @@ When cluster resources are tight, Kubernetes PriorityClasses determine which wor
 | Priority Class | Applies To |
 |---|---|
 | `iomete-compute` | Compute clusters |
-| `iomete-spark-job` | [Spark jobs](/user-guide/spark-jobs/getting-started) |
+| `iomete-spark-job` | [Spark jobs](/user-guide/spark-jobs/creating-spark-job) |
 | `iomete-notebook` | [Jupyter containers](/user-guide/notebook/jupyter-containers) |
 | `iomete-operational-support` | Job Orchestrator workers |
 

--- a/sidebarsUserGuide.js
+++ b/sidebarsUserGuide.js
@@ -204,7 +204,8 @@ const sidebars = {
       label: "Spark Jobs",
       collapsed: true,
       items: [
-        "spark-jobs/getting-started",
+        "spark-jobs/creating-spark-job",
+        "spark-jobs/quick-example",
         "spark-jobs/streaming-jobs",
         "spark-jobs/spark-application-config",
         "spark-jobs/accessing-specific-buckets",

--- a/user-guide/node-types/overview.md
+++ b/user-guide/node-types/overview.md
@@ -9,7 +9,7 @@ last_update:
 
 import Img from '@site/src/components/Img';
 
-A node type is a reusable template that defines CPU (in millicores) and memory (in MiB) for a Spark driver or executor. Rather than entering raw resource values each time you create a [compute cluster](../compute-clusters/overview), [Spark job](../spark-jobs/getting-started.md), or other Spark resource, pick a node type. This keeps sizing consistent and simplifies capacity planning.
+A node type is a reusable template that defines CPU (in millicores) and memory (in MiB) for a Spark driver or executor. Rather than entering raw resource values each time you create a [compute cluster](../compute-clusters/overview), [Spark job](../spark-jobs/creating-spark-job.md), or other Spark resource, pick a node type. This keeps sizing consistent and simplifies capacity planning.
 
 IOMETE seeds cloud-provider-specific defaults on first startup, so you're ready to deploy right away.
 

--- a/user-guide/node-types/spark-resource-selection.md
+++ b/user-guide/node-types/spark-resource-selection.md
@@ -9,7 +9,7 @@ last_update:
 
 import Img from '@site/src/components/Img';
 
-Every Spark-based resource in IOMETE uses node types: [compute clusters](/user-guide/compute-clusters/overview), [Spark jobs](../spark-jobs/getting-started.md), [event streams](/user-guide/event-stream), and [Jupyter containers](../notebook/jupyter-containers.md). When you create or edit any of these, dropdown selectors let you assign a node type for the driver and executor.
+Every Spark-based resource in IOMETE uses node types: [compute clusters](/user-guide/compute-clusters/overview), [Spark jobs](../spark-jobs/creating-spark-job.md), [event streams](/user-guide/event-stream), and [Jupyter containers](../notebook/jupyter-containers.md). When you create or edit any of these, dropdown selectors let you assign a node type for the driver and executor.
 
 <Img src="/img/user-guide/node-types/node-type-select.png" alt="Node type selection in a compute cluster" />
 

--- a/user-guide/spark-jobs/creating-spark-job.md
+++ b/user-guide/spark-jobs/creating-spark-job.md
@@ -11,75 +11,98 @@ import Img from '@site/src/components/Img';
 import { Plus, Code, Cpu } from "@phosphor-icons/react";
 
 
+Each Spark Job runs as an isolated Spark application with its own driver and (optionally) executors. Here's how to create one:
+
 1. In the left sidebar, under **Applications**, click **Job Templates**.
-2. On the Job Templates page, click <button className="button button--primary button-iom"><Plus size={16} /><b>New Job Template</b></button> in the top-right corner.
+2. Click <button className="button button--primary button-iom"><Plus size={16} /><b>New Job Template</b></button> in the top-right corner.
+3. Fill in the form sections described below.
+4. Click <button className="button button--primary button-iom">Create</button> to submit.
+
+You can also click the <button className="button button--primary button-iom"><Code size={16} /></button> button next to Create to view the equivalent cURL command for API-based creation.
 
 <Img src="/img/guides/spark-job/job-create-form.png" alt="Spark Job create form showing Name, Application, and Instance sections" maxWidth="700px"/>
 
-The create form has several sections:
+### General
 
-**General**
+- **Name** (required): A name for the job, e.g. `sample-job`. Allowed characters: alphanumeric, dashes, underscores, dots, and spaces.
+- **Description** (optional): A brief explanation of what the job does.
 
-- **Name** (required): Enter a name for the job, e.g. `sample-job`. Allowed characters: alphanumeric, dashes, underscores, dots, and spaces.
-- **Description** (optional): A brief description of what the job does.
+### Resource Bundle
 
-**Application**
+- **Resource bundle** (required): The [resource bundle](/user-guide/ras/resource-bundles) that defines resource quotas available to this job.
+
+### Namespace
+
+- **Namespace**: The Kubernetes namespace to deploy the job in. Auto-selects if only one namespace exists.
+
+### Run as User
+
+- **Run as user**: The user identity the job runs under. Defaults to the currently logged-in user.
+
+### Schedule
+
+Configure when and how often the job runs. See [Application Config — Schedule](./spark-application-config.md#schedule) for details.
+
+- **Trigger type**: **Manual** (default, run on demand), **Interval** (e.g. every 5 minutes), or **Cron** expression for recurring execution.
+- **Concurrency** (scheduled jobs only): Controls overlap behavior — **Allow**, **Replace**, or **Forbid**.
+
+### Application
+
+Define the code the job runs. See [Application Config — Application](./spark-application-config.md#application) for details.
 
 - **Application type**: Select **Python** (default) or **JVM** (Java, Scala).
-- **Docker registry** + **Docker image**: A compound input. Select the registry from the dropdown (use `default` for IOMETE's built-in registry or choose a [private Docker registry](/user-guide/private-docker-registry)), then enter the image and tag. For our sample job: `iomete/sample-job:1.0.0`
+- **Docker registry** + **Docker image**: Select the registry from the dropdown (use `default` for IOMETE's built-in registry or choose a [private Docker registry](/user-guide/private-docker-registry)), then enter the image and tag (e.g. `iomete/sample-job:1.0.0`).
 - **Main class** (JVM only): The fully qualified class name, e.g. `org.example.MyApp`. Hidden for Python jobs.
-- **Main application file** (required): The entry point of the job. For our sample PySpark job: `local:///app/job.py`. For JVM jobs, use `spark-internal` if the class is already in the classpath.
+- **Main application file** (required): The entry point of the job. For PySpark: `local:///app/job.py`. For JVM jobs, use `spark-internal` if the class is already in the classpath.
 
-**Instance**
+
+### Configurations
+
+Tune Spark behavior and inject runtime settings without rebuilding a Docker image. See [Application Config — Configuration](./spark-application-config.md#configuration) for details.
+
+- **Environment variables**: Key-value pairs injected at runtime.
+- **Spark config**: Standard Spark properties (e.g. `spark.executor.memoryOverhead = 512m`).
+- **Arguments**: Command-line arguments passed to the Spark application.
+- **Java options**: JVM flags for driver and executor processes.
+- **Config maps**: Kubernetes ConfigMaps mounted into the job's pods.
+
+### Dependencies
+
+Pull in external code and packages at Spark startup. See [Application Config — Dependencies](./spark-application-config.md#dependencies) for details.
+
+- **Jar file locations**: URLs or paths to additional JAR files.
+- **Files**: URLs or paths to additional data files.
+- **PY file locations**: Python files (`.py`, `.egg`, or `.zip`) for PySpark.
+- **Maven packages**: Maven coordinates resolved at startup (e.g. `org.apache.spark:spark-avro_2.13:3.5.0`).
+
+### Instance
+
+Configure compute resources for the job. See [Application Config — Instance](./spark-application-config.md#instance-configuration) for details.
 
 - **Deployment type**: Choose **Standard** (clustered, with separate driver and executors) or **Single node** (lightweight, single machine).
-- **Node driver** (required): Select the [node type](/user-guide/node-types/overview) for the Spark driver.
-- **Node executor** + **Executor count** (Standard mode only): Select the [node type](/user-guide/node-types/overview) for executors and how many executors to run.
-- **Executors Volume**: Select a [volume](/user-guide/volumes) for executor (or driver in Single node mode) storage.
+- **Node driver** (required): The [node type](/user-guide/node-types/overview) for the Spark driver.
+- **Node executor** + **Executor count** (Standard mode only): The [node type](/user-guide/node-types/overview) for executors and how many to run.
+- **Executors Volume**: A [volume](/user-guide/volumes) for executor (or driver in Single node mode) storage.
 
-The form also includes the following sections. These can be left at their defaults for your first job:
+### Restart Policy
 
-**Resource bundle** (required)
+Controls automatic restart behavior. See [Application Config — Restart Policy](./spark-application-config.md#restart-policy) for details.
 
-Select a [resource bundle](/user-guide/ras/resource-bundles) that defines the resource quotas available to this job.
+- **Policy**: **Never** (default), **Always**, or **OnFailure**.
+- **Retry counts and intervals** (OnFailure only): Configure retry limits and backoff for both submission and runtime failures.
 
-**Namespace**
+### Max Execution Duration
 
-Select the Kubernetes namespace to deploy the job in. Auto-selects if only one namespace exists.
+- **Max execution duration** (required): The maximum time (in seconds) a job run is allowed to execute before it is terminated. Minimum 60 seconds.
 
-**Run as user**
+### Resource Tags
 
-Choose the user identity the job runs under. Defaults to the currently logged-in user.
+- **Resource tags** (optional): Key-value labels applied to the job's Kubernetes resources. Must follow [Kubernetes label syntax](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).
 
-**Schedule**
+### Advanced Settings
 
-By default, jobs are **manual** (run on demand). You can set an **Interval** (e.g., every 5 minutes) or a **Cron** expression for recurring execution. Scheduled jobs also have a **Concurrency** policy (Allow, Replace, or Forbid) that controls overlap behavior.
-
-**Configurations**
-
-A tabbed section for environment variables, Spark config key-value pairs, application arguments, Java options, and config maps. See [Application Config](./spark-application-config.md) for details.
-
-**Dependencies**
-
-A tabbed section for additional jar files, data files, Python files, and Maven packages. See [Application Config](./spark-application-config.md) for details.
-
-**Restart policy**
-
-Controls automatic restart behavior: **Never** (default), **Always**, or **OnFailure**. When set to OnFailure, you can configure retry counts and intervals for both submission and runtime failures.
-
-**Max execution duration**
-
-The maximum time (in seconds) a job run is allowed to execute before it is terminated. Minimum 60 seconds. Required.
-
-**Resource tags**
-
-Optional key-value labels applied to the job's Kubernetes resources. Must follow [Kubernetes label syntax](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).
-
-**Advanced settings**
-
-When available, configure the deployment flow (**Legacy** or **Priority-Based**) and [execution priority](./job-orchestrator.md) (**Normal** or **High**).
-
-Click <button className="button button--primary button-iom">Create</button> to submit. You can also click the <button className="button button--primary button-iom"><Code size={16} /></button> button next to Create to view the equivalent cURL command for API-based creation.
+- **Deployment flow**: **Legacy** or **Priority-Based** (when available).
+- **Execution priority**: **Normal** or **High**. See [Job Orchestrator](./job-orchestrator.md) for details.
 
 ## Running a Spark Job
 

--- a/user-guide/spark-jobs/creating-spark-job.md
+++ b/user-guide/spark-jobs/creating-spark-job.md
@@ -1,127 +1,24 @@
 ---
-title: Getting Started with Spark Jobs
-sidebar_label: Getting Started
+title: Creating Spark Job
+sidebar_label: Creating Spark Job
 description: Learn how to run your first Spark Job on the IOMETE platform using PySpark. Follow our step-by-step guide and get started with Spark Jobs today!
 last_update:
-  date: 03/16/2026
-  author: Abhishek Pathania
+  date: 04/20/2026
+  author: Ujjawal Khare
 ---
 
 import Img from '@site/src/components/Img';
 import { Plus, Code, Cpu } from "@phosphor-icons/react";
 
-This guide aims to help you get familiar with getting started with writing your first Spark Job and deploying in the IOMETE platform.
-
-:::info
-In this guide, we will use a PySpark sample job but, you can use any other language like Scala, Java or other supported languages.
-:::
-
----
-
-## Quickstart
-
-IOMETE provides a [PySpark quickstart template for AWS](https://github.com/iomete/spark-job-template) or [PySpark quickstart template for GCP](https://github.com/iomete/spark-job-template-gcp) as a starting point for your first Spark Job. Follow the instructions in the `README` file to set up and run it.
-
-## Sample Job
-
-The template already contains a sample job that reads a CSV file from an S3 bucket, runs some transformations, and writes the output to an Iceberg Table.
-
-[Apache Iceberg](https://iceberg.apache.org/) is an open table format for Apache Spark that provides **ACID** transactions, scalable metadata handling, and a unified specification for both **streaming** and **batch** data.
-
-## Using the Template
-
-This template is meant to be used as a starting point for your own jobs. You can use it as follows:
-
-1.  Clone this repository
-2.  Modify the code and tests to fit your needs
-3.  Build the Docker image and push it to your Docker registry
-4.  Create a Spark Job in the IOMETE console
-5.  Run the Spark Job
-6.  Modify the code and tests as needed
-7.  Go to step 3
-
-:::note
-If you are starting with PySpark at IOMETE, explore the sample code without modifying it. It will help you understand the process of creating and running a Spark Job.
-:::
-
-## Project Structure
-
-The project is composed of the following folders/files:
-
-- `infra/`: contains requirements and Dockerfile files
-  - `requirements-dev.txt`: contains the list of python packages to install for development
-  - `requirements.txt`: contains the list of python packages to install for production. This requirements file is used to build the Docker image
-  - `Dockerfile`: contains the Dockerfile to build the spark job image
-- `spark-conf/`: contains the spark configuration files for development environment
-  - `spark-defaults.conf`: contains the spark configuration
-  - `log4j.properties`: contains the log4j configuration for the PySpark job. This file is used to configure the logging level of the job
-- `test_data/`: contains the test data for the job unit/integration tests
-- `job.py`: contains the spark job code. Template comes with a sample code that reads a csv file from S3 and writes the data to a table in the Lakehouse. Feel free to modify the code to fit your needs.
-- `test_job.py`: contains the spark job tests. Template comes with a sample test that reads the test data from `test_data/` and asserts the output of the job. Feel free to modify the tests to fit your needs.
-- `Makefile`: contains the commands to run the job and tests
-
-## Running the Job
-
-First, create a virtual environment and install the dependencies:
-
-```bash
-virtualenv .env
-source .env/bin/activate
-
-# make sure you have Python 3.9 or higher
-make install-dev-requirements
-```
-
-Also, set the `SPARK_CONF_DIR` environment variable to point to the `spark_conf` folder. This is needed to load the spark configuration files for local development:
-
-```bash
-export SPARK_CONF_DIR=./spark_conf
-```
-
-Then, you can run the job:
-
-```bash
-python job.py
-```
-
-## Running the Tests
-
-Make sure you have installed the dependencies and exported the `SPARK_CONF_DIR` environment variable as described in the previous section.
-
-To run the tests, use the `pytest` command:
-
-```bash
-pytest
-```
-
-## Deployment
-
-### Build Docker Image
-
-In the Makefile, modify `docker_image` and `docker_tag` variables to match your Docker image name and tag.
-
-:::info
-For example, if you push your image to AWS ECR, your docker image name will be something like `123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image`.
-:::
-
-Then, run the following command to build the Docker image:
-
-```bash
-make docker-push
-```
-
-Once the docker is built and pushed to your Docker registry, you can create a Spark Job in the IOMETE.
-
-## Creating a Spark Job
 
 1. In the left sidebar, under **Applications**, click **Job Templates**.
 2. On the Job Templates page, click <button className="button button--primary button-iom"><Plus size={16} /><b>New Job Template</b></button> in the top-right corner.
 
 <Img src="/img/guides/spark-job/job-create-form.png" alt="Spark Job create form showing Name, Application, and Instance sections" maxWidth="700px"/>
 
-The create form has several sections. For a quickstart, focus on these essentials:
+The create form has several sections:
 
-**Name**
+**General**
 
 - **Name** (required): Enter a name for the job, e.g. `sample-job`. Allowed characters: alphanumeric, dashes, underscores, dots, and spaces.
 - **Description** (optional): A brief description of what the job does.
@@ -137,8 +34,8 @@ The create form has several sections. For a quickstart, focus on these essential
 
 - **Deployment type**: Choose **Standard** (clustered, with separate driver and executors) or **Single node** (lightweight, single machine).
 - **Node driver** (required): Select the [node type](/user-guide/node-types/overview) for the Spark driver.
-- **Node executor** + **Executor count** (Standard mode only): Select the [node type](/user-guide/node-types/overview) for executors and how many to run.
-- **Volume**: Select a [volume](/user-guide/volumes) for executor (or driver in Single node mode) storage.
+- **Node executor** + **Executor count** (Standard mode only): Select the [node type](/user-guide/node-types/overview) for executors and how many executors to run.
+- **Executors Volume**: Select a [volume](/user-guide/volumes) for executor (or driver in Single node mode) storage.
 
 The form also includes the following sections. These can be left at their defaults for your first job:
 
@@ -180,7 +77,7 @@ Optional key-value labels applied to the job's Kubernetes resources. Must follow
 
 **Advanced settings**
 
-When available, configure the deployment flow (**Legacy** or **Priority-Based**) and execution priority (**Normal** or **High**).
+When available, configure the deployment flow (**Legacy** or **Priority-Based**) and [execution priority](./job-orchestrator.md) (**Normal** or **High**).
 
 Click <button className="button button--primary button-iom">Create</button> to submit. You can also click the <button className="button button--primary button-iom"><Code size={16} /></button> button next to Create to view the equivalent cURL command for API-based creation.
 

--- a/user-guide/spark-jobs/creating-spark-job.md
+++ b/user-guide/spark-jobs/creating-spark-job.md
@@ -8,7 +8,7 @@ last_update:
 ---
 
 import Img from '@site/src/components/Img';
-import { Plus, Code, Cpu } from "@phosphor-icons/react";
+import { Plus, Code } from "@phosphor-icons/react";
 
 
 Each Spark Job runs as an isolated Spark application with its own driver and (optionally) executors. Here's how to create one:

--- a/user-guide/spark-jobs/quick-example.md
+++ b/user-guide/spark-jobs/quick-example.md
@@ -51,7 +51,7 @@ The project is composed of the following folders/files:
   - `requirements-dev.txt`: contains the list of python packages to install for development
   - `requirements.txt`: contains the list of python packages to install for production. This requirements file is used to build the Docker image
   - `Dockerfile`: contains the Dockerfile to build the spark job image
-- `spark-conf/`: contains the spark configuration files for development environment
+- `spark_conf/`: contains the spark configuration files for development environment
   - `spark-defaults.conf`: contains the spark configuration
   - `log4j.properties`: contains the log4j configuration for the PySpark job. This file is used to configure the logging level of the job
 - `test_data/`: contains the test data for the job unit/integration tests

--- a/user-guide/spark-jobs/quick-example.md
+++ b/user-guide/spark-jobs/quick-example.md
@@ -7,9 +7,6 @@ last_update:
   author: Ujjawal Khare
 ---
 
-import Img from '@site/src/components/Img';
-import { Plus, Code, Cpu } from "@phosphor-icons/react";
-
 This guide walks you through writing, testing, and deploying your first Spark Job on the IOMETE platform. By the end, you'll have a working PySpark job running in IOMETE.
 
 :::info

--- a/user-guide/spark-jobs/quick-example.md
+++ b/user-guide/spark-jobs/quick-example.md
@@ -10,7 +10,7 @@ last_update:
 import Img from '@site/src/components/Img';
 import { Plus, Code, Cpu } from "@phosphor-icons/react";
 
-This guide aims to help you get familiar with getting started with writing your first Spark Job and deploying in the IOMETE platform.
+This guide walks you through writing, testing, and deploying your first Spark Job on the IOMETE platform. By the end, you'll have a working PySpark job running in IOMETE.
 
 :::info
 In this guide, we will use a PySpark sample job but, you can use any other language like Scala, Java or other supported languages.
@@ -30,15 +30,14 @@ The template already contains a sample job that reads a CSV file from an S3 buck
 
 ## Using the Template
 
-This template is meant to be used as a starting point for your own jobs. You can use it as follows:
+This template is meant to be used as a starting point for your own jobs. The typical workflow is:
 
-1.  Clone this repository
+1.  Clone the repository
 2.  Modify the code and tests to fit your needs
 3.  Build the Docker image and push it to your Docker registry
-4.  Create a Spark Job in the IOMETE console
+4.  [Create a Spark Job](./creating-spark-job.md) in the IOMETE console
 5.  Run the Spark Job
-6.  Modify the code and tests as needed
-7.  Go to step 3
+6.  Iterate — modify code, rebuild, and redeploy
 
 :::note
 If you are starting with PySpark at IOMETE, explore the sample code without modifying it. It will help you understand the process of creating and running a Spark Job.
@@ -110,4 +109,8 @@ Then, run the following command to build the Docker image:
 make docker-push
 ```
 
-Once the docker is built and pushed to your Docker registry, you can create a Spark Job in the IOMETE.
+Once the image is pushed to your Docker registry, you're ready to deploy it. Head over to [Creating Spark Job](./creating-spark-job.md) to set up the job in the IOMETE console. Use the following values in the **Application** section:
+
+- **Docker registry**: Select the registry where you pushed the image (or `default` if using IOMETE's built-in registry).
+- **Docker image**: Enter your image and tag, e.g. `your-registry/your-image:1.0.0`.
+- **Main application file**: `local:///app/job.py`

--- a/user-guide/spark-jobs/quick-example.md
+++ b/user-guide/spark-jobs/quick-example.md
@@ -1,0 +1,113 @@
+---
+title: Quick example of Spark Job
+sidebar_label: Quick Example
+description: Learn how to run your first Spark Job on the IOMETE platform using PySpark. Follow our step-by-step guide and get started with Spark Jobs today!
+last_update:
+  date: 04/20/2026
+  author: Ujjawal Khare
+---
+
+import Img from '@site/src/components/Img';
+import { Plus, Code, Cpu } from "@phosphor-icons/react";
+
+This guide aims to help you get familiar with getting started with writing your first Spark Job and deploying in the IOMETE platform.
+
+:::info
+In this guide, we will use a PySpark sample job but, you can use any other language like Scala, Java or other supported languages.
+:::
+
+---
+
+## Quickstart
+
+IOMETE provides a [PySpark quickstart template for AWS](https://github.com/iomete/spark-job-template) or [PySpark quickstart template for GCP](https://github.com/iomete/spark-job-template-gcp) as a starting point for your first Spark Job. Follow the instructions in the `README` file to set up and run it.
+
+## Sample Job
+
+The template already contains a sample job that reads a CSV file from an S3 bucket, runs some transformations, and writes the output to an Iceberg Table.
+
+[Apache Iceberg](https://iceberg.apache.org/) is an open table format for Apache Spark that provides **ACID** transactions, scalable metadata handling, and a unified specification for both **streaming** and **batch** data.
+
+## Using the Template
+
+This template is meant to be used as a starting point for your own jobs. You can use it as follows:
+
+1.  Clone this repository
+2.  Modify the code and tests to fit your needs
+3.  Build the Docker image and push it to your Docker registry
+4.  Create a Spark Job in the IOMETE console
+5.  Run the Spark Job
+6.  Modify the code and tests as needed
+7.  Go to step 3
+
+:::note
+If you are starting with PySpark at IOMETE, explore the sample code without modifying it. It will help you understand the process of creating and running a Spark Job.
+:::
+
+## Project Structure
+
+The project is composed of the following folders/files:
+
+- `infra/`: contains requirements and Dockerfile files
+  - `requirements-dev.txt`: contains the list of python packages to install for development
+  - `requirements.txt`: contains the list of python packages to install for production. This requirements file is used to build the Docker image
+  - `Dockerfile`: contains the Dockerfile to build the spark job image
+- `spark-conf/`: contains the spark configuration files for development environment
+  - `spark-defaults.conf`: contains the spark configuration
+  - `log4j.properties`: contains the log4j configuration for the PySpark job. This file is used to configure the logging level of the job
+- `test_data/`: contains the test data for the job unit/integration tests
+- `job.py`: contains the spark job code. Template comes with a sample code that reads a csv file from S3 and writes the data to a table in the Lakehouse. Feel free to modify the code to fit your needs.
+- `test_job.py`: contains the spark job tests. Template comes with a sample test that reads the test data from `test_data/` and asserts the output of the job. Feel free to modify the tests to fit your needs.
+- `Makefile`: contains the commands to run the job and tests
+
+## Running the Job
+
+First, create a virtual environment and install the dependencies:
+
+```bash
+virtualenv .env
+source .env/bin/activate
+
+# make sure you have Python 3.9 or higher
+make install-dev-requirements
+```
+
+Also, set the `SPARK_CONF_DIR` environment variable to point to the `spark_conf` folder. This is needed to load the spark configuration files for local development:
+
+```bash
+export SPARK_CONF_DIR=./spark_conf
+```
+
+Then, you can run the job:
+
+```bash
+python job.py
+```
+
+## Running the Tests
+
+Make sure you have installed the dependencies and exported the `SPARK_CONF_DIR` environment variable as described in the previous section.
+
+To run the tests, use the `pytest` command:
+
+```bash
+pytest
+```
+
+## Deployment
+
+### Build Docker Image
+
+In the Makefile, modify `docker_image` and `docker_tag` variables to match your Docker image name and tag.
+
+:::info
+For example, if you push your image to AWS ECR, your docker image name will be something like `123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image`.
+:::
+
+Then, run the following command to build the Docker image:
+
+```bash
+make docker-push
+```
+
+Once the docker is built and pushed to your Docker registry, you can create a Spark Job in the IOMETE.

--- a/user-guide/spark-jobs/spark-application-config.md
+++ b/user-guide/spark-jobs/spark-application-config.md
@@ -9,7 +9,7 @@ last_update:
 
 import Img from '@site/src/components/Img';
 
-This page covers every configuration option for creating or editing a Spark Job, organized by form section to match the console layout. For a step-by-step walkthrough, see [Getting Started](creating-spark-job.md).
+This page covers every configuration option for creating or editing a Spark Job, organized by form section to match the console layout. For a step-by-step walkthrough, see [Creating Spark Job](creating-spark-job.md).
 
 :::info Permissions
 Creating and managing Spark Jobs requires appropriate IAM permissions within your domain. Contact your domain owner if you cannot access the Job Templates page.

--- a/user-guide/spark-jobs/spark-application-config.md
+++ b/user-guide/spark-jobs/spark-application-config.md
@@ -9,7 +9,7 @@ last_update:
 
 import Img from '@site/src/components/Img';
 
-This page covers every configuration option for creating or editing a Spark Job, organized by form section to match the console layout. For a step-by-step walkthrough, see [Getting Started](./getting-started.md).
+This page covers every configuration option for creating or editing a Spark Job, organized by form section to match the console layout. For a step-by-step walkthrough, see [Getting Started](creating-spark-job.md).
 
 :::info Permissions
 Creating and managing Spark Jobs requires appropriate IAM permissions within your domain. Contact your domain owner if you cannot access the Job Templates page.

--- a/user-guide/spark-jobs/streaming-jobs.md
+++ b/user-guide/spark-jobs/streaming-jobs.md
@@ -9,7 +9,7 @@ last_update:
 
 import Img from '@site/src/components/Img';
 
-Streaming Jobs are long-running Spark applications built for continuous data processing: real-time ingestion, event processing, and anything that needs always-on execution. Unlike regular [Spark Jobs](./getting-started.md), which run on a schedule or on demand, Streaming Jobs run indefinitely until you stop them.
+Streaming Jobs are long-running Spark applications built for continuous data processing: real-time ingestion, event processing, and anything that needs always-on execution. Unlike regular [Spark Jobs](creating-spark-job.md), which run on a schedule or on demand, Streaming Jobs run indefinitely until you stop them.
 
 :::info Key Differences From Spark Jobs
 Streaming Jobs share the same form and compute infrastructure as regular Spark Jobs, but differ in a few ways:

--- a/user-guide/volumes.md
+++ b/user-guide/volumes.md
@@ -184,7 +184,7 @@ Ensure your NFS server is properly configured with correct export permissions an
 
 ## Using volumes
 
-You can utilize node types in [Compute Clusters](./compute-clusters/overview) and [Spark Jobs](./spark-jobs/getting-started.md).
+You can utilize node types in [Compute Clusters](./compute-clusters/overview) and [Spark Jobs](spark-jobs/creating-spark-job.md).
 Let's navigate to the [Cluster create](./compute-clusters/creating-clusters) page. Here, you'll find options for `Volume` which include volume selections.
 
 <Img src="/img/user-guide/volumes/select-volume.png" alt="Lakehouse Volume select" maxWidth="600px"/>

--- a/user-guide/volumes.md
+++ b/user-guide/volumes.md
@@ -184,7 +184,7 @@ Ensure your NFS server is properly configured with correct export permissions an
 
 ## Using volumes
 
-You can utilize node types in [Compute Clusters](./compute-clusters/overview) and [Spark Jobs](spark-jobs/creating-spark-job.md).
+You can utilize node types in [Compute Clusters](./compute-clusters/overview) and [Spark Jobs](./spark-jobs/creating-spark-job.md).
 Let's navigate to the [Cluster create](./compute-clusters/creating-clusters) page. Here, you'll find options for `Volume` which include volume selections.
 
 <Img src="/img/user-guide/volumes/select-volume.png" alt="Lakehouse Volume select" maxWidth="600px"/>

--- a/userGuideRedirects.js
+++ b/userGuideRedirects.js
@@ -29,7 +29,8 @@ const userGuideRedirects = [
   { from: "/developer-guide/notebook/using-jupyterlab", to: "/user-guide/notebook/using-jupyterlab" },
 
   // Spark Jobs (developer-guide/spark-job → user-guide/spark-jobs)
-  { from: "/developer-guide/spark-job/getting-started", to: "/user-guide/spark-jobs/getting-started" },
+  { from: "/developer-guide/spark-job/getting-started", to: "/user-guide/spark-jobs/creating-spark-job" },
+  { from: "/user-guide/spark-jobs/getting-started", to: "/user-guide/spark-jobs/creating-spark-job" },
   { from: "/developer-guide/spark-job/spark-application-config", to: "/user-guide/spark-jobs/spark-application-config" },
   { from: "/developer-guide/spark-job/iomete-sdk", to: "/user-guide/spark-jobs/iomete-sdk" },
   { from: "/developer-guide/spark-job/airflow", to: "/user-guide/spark-jobs/airflow" },


### PR DESCRIPTION
This PR updates the Spark Jobs user-guide by replacing the old “Getting Started” page with a new “Creating Spark Job” page, adding a “Quick Example”, and updating internal/external links and redirects so existing URLs continue to work.

Changes:

- Replace /user-guide/spark-jobs/getting-started content with new docs (creating-spark-job, quick-example) and update the user guide sidebar accordingly.
- Update cross-doc links (user guide, docs, blog) to point to the new Spark Jobs entry page.
- Add redirects for legacy Spark Job URLs (developer-guide → user-guide and old user-guide path).