### PR TITLE
Bump picomatch to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "sharp": "^0.34.5",
     "tailwindcss": "^3.4.19"
   },
+  "resolutions": {
+    "**/@parcel/watcher/picomatch": "^4.0.4",
+    "**/picomatch": "^2.3.2"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8182,15 +8182,15 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1, picomatch@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+picomatch@^4.0.3, picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Summary

Four open Dependabot alerts (#200–#203) flag picomatch for a high-severity ReDoS via extglob quantifiers (CVE-2026-33671) and a medium-severity method injection in POSIX character classes. Two vulnerable versions are currently pinned in `yarn.lock` — `2.3.1` (pulled by chokidar, tailwindcss, rollup, docusaurus bundler, etc.) and `4.0.3` (pulled only by `@parcel/watcher`).

## What

Adds a yarn `resolutions` block to force both majors to patched versions:

- `**/picomatch` → `^2.3.2` for the many `^2.x` consumers
- `**/@parcel/watcher/picomatch` → `^4.0.4` so we don't downgrade `@parcel/watcher`'s `^4.0.3` requirement to a v2

After `yarn install`, `yarn why picomatch` confirms only `2.3.2` and `4.0.4` are resolved. Scope is intentionally narrow — the other open alerts (lodash-es, path-to-regexp, serialize-javascript, minimatch, brace-expansion, webpack) are not touched here.

## Testing

- `yarn install` succeeds with resolutions applied.
- `yarn why picomatch` shows only `2.3.2` (hoisted) and `@parcel/watcher`'s nested `4.0.4`.
- `yarn build` completes successfully in ~134s with no new warnings.

## Relevant links

- Dependabot: https://github.com/iomete/iom-docs/security/dependabot (alerts #200, #201, #202, #203)
- Advisory: https://github.com/advisories/GHSA-c2c7-rcm5-vvqj

## Rollout

No special rollout considerations. Docs-site–only dependency bump, both packages are transitive build-time deps, and the patched versions are semver-compatible minors/patches. If anything breaks, revert the commit.