### PR TITLE
docs(aws): rewrite S3 bucket permissions with correct IAM model

### DIFF
--- a/user-guide/aws/s3-bucket-permissions.md
+++ b/user-guide/aws/s3-bucket-permissions.md
@@ -1,75 +1,53 @@
 ---
 title: AWS S3 Buckets Access
 sidebar_label: S3 Buckets Access
-description: Learn how to provide access to external S3 buckets in IOMETE, a hybrid (cloud & on-premises based) data platform for data storage and analysis. This guide outlines simple steps to connect to S3 buckets and grant permission to the Lakehouse role.
+description: Learn how S3 bucket access works for IOMETE data planes on AWS and outside AWS, and how to grant the right permissions.
 last_update:
-  date: 05/05/2024
-  author: Vusal Dadalov
+  date: 04/28/2026
+  author: Sourabh Jajoria
 ---
 
-IOMETE is a hybrid (cloud & on-premises) platform that allows users to store, manage, and analyze large amounts of data.
-One of the key features of IOMETE is the ability to connect any S3 buckets and access data from them.
+How IOMETE accesses S3 depends on where your data plane runs.
 
-In order to do this, you need to provide permission to the `Lakehouse Role`.
+**On AWS**, the Lakehouse Spark pods run under the Kubernetes service account `lakehouse-service-account`, which is annotated with an IAM role ARN. The EKS OIDC provider federates that Kubernetes identity to an AWS IAM role (IRSA), so pods can access S3 without static credentials. To find your Lakehouse Role ARN, go to **Console > Settings > Data Plane > General**.
 
-:::info
-To find the Lakehouse role, go to the IOMETE **Console > Settings > Data Plane > General** and look for
-the `Lakehouse Role ARN` field.
-:::
+**Outside AWS** (MinIO, Dell ECS, on-prem), the data plane uses static access/secret keys pointed at the S3-compatible service endpoint (e.g. `http://minio.my-cluster:9000`). These credentials cannot authenticate against AWS S3 — the rest of this page applies to AWS deployments only.
 
-:::info `What is the Lakehouse Role?`
-The Lakehouse role is an AWS IAM role that is used by IOMETE Data Plane compute resources to access external S3 buckets.
-The Lakehouse role is created during the IOMETE Data Plane installation process.
-:::
+## Granting Access to an External S3 Bucket (AWS)
 
-## Options to provide access to S3 buckets
+There are two ways to grant the Lakehouse role access to an external bucket:
 
-AWS provides essentially two ways to provide access to S3 buckets:
+1. **[Bucket Policy](#bucket-policy)** — add a policy on the external bucket that allows the Lakehouse role as a principal. No IAM console access required.
+2. **[IAM Role Policy](#iam-role-policy)** — attach a policy directly to the Lakehouse role. Requires IAM console access.
 
-1. [Bucket Policy](#bucket-policy): You can create a bucket policy that allows access to the S3 bucket from the
-   Lakehouse role.
-2. [IAM Role Policy](#iam-role-policy): You can create an IAM role policy that allows access to the S3 bucket and attach
-   it to the Lakehouse role.
+Both methods use the same set of S3 actions. For read-only access, only `s3:GetObject` and `s3:ListBucket` are needed.
 
 ---
 
 ## Bucket Policy
 
-The easiest way to grant access to the Lakehouse role is to create a bucket policy that allows the role to access the
-bucket. Since the Lakehouse clusters, Spark jobs, and notebooks are all running under the Lakehouse role, you only need
-to provide access to the Lakehouse role.
+1. Go to your [S3 console](https://s3.console.aws.amazon.com/s3/home) and select your bucket.
+2. Click **Permissions → Bucket Policy**.
+3. Paste one of the examples below, replacing `<lakehouse_role>` with the Lakehouse Role ARN and `<your_bucket>` with your bucket name.
+4. Click **Save**.
 
-To set the bucket policy, you need to navigate to your S3 bucket's permissions page.
+### Full read/write access
 
-1. Go to your [S3 console](https://s3.console.aws.amazon.com/s3/home) and select your desired bucket.
-2. Click on the "Permissions" tab, and then click on "Bucket Policy".
-3. Copy and paste the appropriate policy from the examples below into the bucket policy editor.
-4. Replace `<lakehouse_role>` with the name of your Lakehouse role, and `<your_bucket>` with the name of your S3 bucket.
-5. Click on "Save".
-
-Once saved, you should see a message at the top of the page that says "Bucket policy has been updated." You have now
-successfully granted access to your external S3 bucket for your Lakehouse role!
-
-### Example 1. Full read/write access to your bucket from Lakehouse role:
-
-Let's say you have a bucket called `my-bucket` and you want to give access to the Lakehouse role. You can create a
-bucket policy that looks like this. Replace `<lakehouse_role>` with the Lakehouse role and `<your_bucket>` with the name
-of your bucket.
-
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": {
-                "AWS": [
-                    "<lakehouse_role>"
-                ]
-            },
+            "Principal": { "AWS": ["<lakehouse_role>"] },
             "Action": [
-                "s3:*Object",
-                "s3:ListBucket"
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
             ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
@@ -80,25 +58,16 @@ of your bucket.
 }
 ```
 
-This policy provides full read/write access to your bucket from the Lakehouse role.
+### Read-only access
 
-### Example 2. Read-only access to your bucket from Lakehouse role:
-
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": {
-                "AWS": [
-                    "<lakehouse_role>"
-                ]
-            },
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
+            "Principal": { "AWS": ["<lakehouse_role>"] },
+            "Action": ["s3:GetObject", "s3:ListBucket"],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -108,26 +77,18 @@ This policy provides full read/write access to your bucket from the Lakehouse ro
 }
 ```
 
-Only the highlighted line is different from the previous policy.
-This policy provides read-only access to your bucket from the Lakehouse role.
+### Read-only access to a specific folder
 
-### Example 3. Read-only access to a specific folder in your bucket from Lakehouse role:
+Replace `folder` with your prefix.
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": {
-                "AWS": [
-                    "<lakehouse_role>"
-                ]
-            },
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
+            "Principal": { "AWS": ["<lakehouse_role>"] },
+            "Action": ["s3:GetObject", "s3:ListBucket"],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/folder/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -136,48 +97,37 @@ This policy provides read-only access to your bucket from the Lakehouse role.
     ]
 }
 ```
-
-See highlighted lines for the difference from the previous policy. This policy provides read-only access to a specific
-folder in your bucket from the Lakehouse role.
 
 ---
 
 ## IAM Role Policy
 
-Another way to provide access to the Lakehouse role is to create an IAM role policy that allows access to the S3 bucket
-and attach it to the Lakehouse role.
-
-### Attaching the IAM Role Policy
-
-To attach the IAM role policy to the Lakehouse role, you need to navigate to the IAM console.
-
-1. Go to your [IAM console](https://console.aws.amazon.com/iam/home) and select `Roles` from the left-hand menu.
-2. Search for the Lakehouse role in the list of roles and click on it.
-3. Click on the Permissions tab, and then click on Add `inline policy`.
-4. See below for the examples to create a policy. You can copy and paste the policy into the JSON editor.
-5. Click on `Review policy`. Give your policy a name and click on `Create policy`.
-
-You have now successfully attached the IAM role policy to the Lakehouse role. You can now use the Lakehouse role to
-access the S3 bucket from IOMETE.
+1. Go to your [IAM console](https://console.aws.amazon.com/iam/home) and select **Roles**.
+2. Search for the Lakehouse role and click it.
+3. Click **Permissions → Add inline policy**, paste one of the examples below, and save.
 
 :::note
-Alternative to `Inline policy`, you can also create a `Managed policy` from `Policies` in the IAM console and attach it
-to the Lakehouse role.
+You can also create a **Managed policy** under **Policies** and attach it to the Lakehouse role instead.
 :::
 
-Here are some examples of IAM role policies that you can attach to the Lakehouse role:
+IAM role policies do not include a `Principal` field — the policy is scoped to the role it's attached to.
 
-### Example 1. Full read/write access to your bucket:
+### Full read/write access
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
             "Action": [
-                "s3:*Object",
-                "s3:ListBucket"
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
             ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
@@ -188,25 +138,15 @@ Here are some examples of IAM role policies that you can attach to the Lakehouse
 }
 ```
 
-Replace `<your_bucket>` with the name of your S3 bucket that you want to provide access to.
+### Read-only access
 
-:::info
-You already noticed that, IAM role policy does not require to specify the `Principal` field as it is already attached to
-the Lakehouse role.
-:::
-
-### Example 2. Read-only access to your bucket:
-
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
+            "Action": ["s3:GetObject", "s3:ListBucket"],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -216,20 +156,15 @@ the Lakehouse role.
 }
 ```
 
-Only the highlighted line is different from the previous policy.
+### Read-only access to a specific folder
 
-### Example 3. Read-only access to a specific folder in your bucket:
-
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
+            "Action": ["s3:GetObject", "s3:ListBucket"],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/folder/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -239,13 +174,6 @@ Only the highlighted line is different from the previous policy.
 }
 ```
 
-See highlighted lines for the difference from the previous policy.
-
 :::info
-In the `Resource` field, you can specify multiple resources by separating them with a comma do provide access to
-multiple buckets or folders.
+To grant access to multiple buckets or folders, add additional entries to the `Resource` array.
 :::
-
----
-If you have any questions or need further assistance, please feel free to reach out to our support team. We are always
-here to help you with any questions or issues you may have.


### PR DESCRIPTION
## Summary

- Rewrites `user-guide/aws/s3-bucket-permissions.md` to correctly explain the two S3 access models validated against source code (Terraform + Kotlin monorepo)
- **AWS deployments (IRSA)**: `lakehouse-service-account` is annotated with an IAM role ARN; EKS OIDC federates the pod identity via `WebIdentityTokenFileCredentialsProvider` in `core-site.xml` — no static credentials
- **Non-AWS deployments (MinIO, Dell ECS)**: static access/secret keys + service endpoint written into as a K8s Secret at data plane init time; credentials are global (no per-bucket override)
- Fixes policy code fence language (`js` → `json`), removes orphaned "highlighted line" references, and eliminates duplicate explanatory sections
