### PR TITLE
docs(aws): targeted S3 integration fixes

### DIFF
--- a/docs/tutorials/aws/read-files-from-aws-s3.md
+++ b/docs/tutorials/aws/read-files-from-aws-s3.md
@@ -16,7 +16,7 @@ import { File, FileCsv, FileJs } from "@phosphor-icons/react";
 This is an end-to-end guide about how to move files from your AWS S3 to IOMETE.
 
 :::info Your files in AWS S3
-Let's assume you have an external bucket in AWS S3 with the CSV files you want to query in IOMETE. In this example, we will use the `area-for-iomete` bucket.
+Let's assume you have an external bucket in AWS S3 with the files you want to query in IOMETE. In this example, we will use the `area-for-iomete` bucket with a `countries.json` file.
 :::
 
 ## Provide permissions to IOMETE

--- a/docs/tutorials/aws/read-files-from-aws-s3.md
+++ b/docs/tutorials/aws/read-files-from-aws-s3.md
@@ -8,6 +8,10 @@ last_update:
 
 import Img from '@site/src/components/Img';
 
+import Card from "@site/src/components/Card";
+import GridBox from "@site/src/components/GridBox";
+import { File, FileCsv, FileJs } from "@phosphor-icons/react";
+
 
 This is an end-to-end guide about how to move files from your AWS S3 to IOMETE.
 
@@ -31,7 +35,27 @@ Always reference S3 paths with `s3a://`, not `s3://` or `s3n://`. IOMETE's Spark
 SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
 ```
 
-For per-format configuration options (CSV, JSON, Parquet, ORC), see [Query Federation](../../reference/sql-quick-start/query-federation.md).
+Learn more about querying files like CSV, JSON, Parquet, ORC and more detailed configuration options in the following guides:
+
+<GridBox>
+
+<Card title="CSV Files" icon={<FileCsv />} link="user-guide/reference/data-sources/csv-files">
+Learn how to query CSV files in IOMETE and options to configure the CSV data source
+</Card>
+
+<Card title="JSON Files" icon={<FileJs />} link="user-guide/reference/data-sources/json-files">
+Learn how to query JSON files in IOMETE and options to configure the JSON data source
+</Card>
+
+<Card title="Parquet Files" icon={<File />} link="user-guide/reference/data-sources/parquet-files">
+Learn how to query Parquet files in IOMETE and options to configure the Parquet data source
+</Card>
+
+<Card title="ORC Files" icon={<File />} link="user-guide/reference/data-sources/orc-files">
+Learn how to query ORC files in IOMETE and options to configure the ORC data source
+</Card>
+
+</GridBox>
 
 ## Moving data into the lakehouse
 

--- a/docs/tutorials/aws/read-files-from-aws-s3.md
+++ b/docs/tutorials/aws/read-files-from-aws-s3.md
@@ -1,91 +1,101 @@
 ---
 slug: /aws/read-files-from-aws-s3
 title: Querying Files in AWS S3
-description: Querying Files in AWS S3 with IOMETE. This is an end-to-end guide about how to query and move files from your AWS S3 to IOMETE
+description: Read CSV, JSON, Parquet, and ORC files directly from an external S3 bucket with IOMETE SQL, then move that data into managed Iceberg tables in the Lakehouse.
+sidebar_label: Read Files from S3
 last_update:
-  date: 05/04/2023
+  date: 04/29/2026
+  author: Sourabh Jajoria
 ---
 
 import Img from '@site/src/components/Img';
 
-import Card from "@site/src/components/Card";
-import GridBox from "@site/src/components/GridBox";
-import { File, FileCsv, FileJs } from "@phosphor-icons/react";
+## Introduction
 
-This is an end-to-end guide about how to move files from your AWS S3 to IOMETE.
+Most data teams keep raw files in S3 long before they're ready to land in a curated table. This tutorial walks you through querying those files in place from the IOMETE SQL Editor, then promoting the data into managed Iceberg tables in the IOMETE Lakehouse when you're ready. Every example uses standard Spark SQL (no custom IOMETE syntax), so the same queries run from a SQL Editor worksheet, a Spark Job, or a Jupyter notebook.
 
-:::info Your files in AWS S3
-Let's assume you have an external bucket in AWS S3 with the CSV files you want to query in IOMETE. In this example, we will use the `area-for-iomete` bucket.
+:::info
+The examples assume you have an external bucket called `area-for-iomete` containing a `countries.json` file. Replace the bucket and file names with your own.
 :::
 
-## Provide permissions to IOMETE
+## Common Use Cases
 
-In order to access files in this external S3 bucket, IOMETE requires permissions to read/write the files. Follow [this guide](/user-guide/aws/s3-bucket-permissions) to provide the necessary permissions.
+The patterns below cover the situations where reading directly from S3 saves you a round trip through ingestion tooling:
 
-## Querying files in AWS S3
+- Exploring ad-hoc CSV, JSON, Parquet, or ORC files in S3 without registering them as tables first.
+- Bulk-loading data from an external bucket into the Lakehouse with `CREATE TABLE AS SELECT`.
+- Appending or merging incremental file drops into an existing managed Iceberg table.
 
-It's extremely easy to query files in AWS S3 with IOMETE. You just need to provide the bucket name and the path to the file you want to query.
+## Prerequisites
+
+IOMETE needs permission to read the bucket before any of these queries work. The ingestion examples later in this tutorial also need write access. Follow the [AWS S3 Buckets Access](/user-guide/aws/s3-bucket-permissions) guide to update the bucket policy and the IOMETE Lakehouse IAM role.
+
+:::info Use the `s3a://` Scheme
+Always reference S3 paths with `s3a://`, not `s3://` or `s3n://`. IOMETE's Spark runtime registers only the Hadoop S3A driver, so `s3://` raises `No FileSystem for scheme: s3`.
+:::
+
+## Step 1: Querying a File in S3
+
+The fastest way to inspect a file is to skip the table registration step entirely and let Spark read it directly. Open the **SQL Editor** in your domain and use the file-format shorthand `<format>.\`<path>\``, where `<format>` is one of `csv`, `json`, `parquet`, or `orc`.
 
 ```sql
-SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
+SELECT * FROM json.`s3a://area-for-iomete/countries.json`;
 ```
 
-Learn more about querying files like CSV, JSON, Parquet, ORC and more detailed configuration options in the following guides:
+The same pattern works for other formats:
 
-<GridBox>
+```sql
+SELECT * FROM csv.`s3a://area-for-iomete/sales.csv`;
+SELECT * FROM parquet.`s3a://area-for-iomete/events.parquet`;
+SELECT * FROM orc.`s3a://area-for-iomete/logs/`;
+```
 
-<Card title="CSV Files" icon={<FileCsv />} link="user-guide/reference/data-sources/csv-files">
-Learn how to query CSV files in IOMETE and options to configure the CSV data source
-</Card>
+Nothing gets created in the catalog. Spark reads the file on the fly and streams the rows back to the editor.
 
-<Card title="JSON Files" icon={<FileJs />} link="user-guide/reference/data-sources/json-files">
-Learn how to query JSON files in IOMETE and options to configure the JSON data source
-</Card>
+{/* SCREENSHOT NEEDED: SQL Editor with the json.`s3a://...` query and result rows. */}
 
-<Card title="Parquet Files" icon={<File />} link="user-guide/reference/data-sources/parquet-files">
-Learn how to query Parquet files in IOMETE and options to configure the Parquet data source
-</Card>
+## Step 2: Moving Data Into the Lakehouse
 
-<Card title="ORC Files" icon={<File />} link="user-guide/reference/data-sources/orc-files">
-Learn how to query ORC files in IOMETE and options to configure the ORC data source
-</Card>
+Reading in place is great for exploration, but you'll usually want the data in a managed Iceberg table for downstream queries, governance, and time travel. Three patterns cover almost every ingestion scenario. Pick the one that matches what you need.
 
-</GridBox>
+### Option 1: Create a Table From the Query
 
-## Moving data into the lakehouse
+Use `CREATE TABLE AS SELECT` (CTAS) to spin up a fresh managed table populated with the file's rows:
 
-If you want to move files to IOMETE Lakehouse, which provides a managed data lake experience, you can use the following commands to create tables and insert data into them.
-
-### Non-partitioned Table
-
-- **Option 1. Create a table from select**
-
-```sql SQL
--- Create table directly from the query
+```sql
+-- Create a managed Iceberg table directly from the query
 CREATE TABLE countries
-AS SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
+AS SELECT * FROM json.`s3a://area-for-iomete/countries.json`;
 
--- To inspect the table use the following query
+-- Inspect the resulting schema, location, and table properties
 DESC TABLE EXTENDED countries;
 ```
 
-- **Option 2. Insert into to existing table**
+:::info
+`CREATE TABLE` produces an Iceberg table by default. IOMETE sets `spark.sql.sources.default = iceberg` globally, so you don't need a `USING iceberg` clause.
+:::
+
+### Option 2: Insert Into an Existing Table
+
+If the target table already exists, append new rows or replace all of them:
 
 ```sql
--- just append data
+-- Append rows
 INSERT INTO countries
-SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
+SELECT * FROM json.`s3a://area-for-iomete/countries.json`;
 
--- first clean an existing data and then insert new data
+-- Replace all rows atomically
 INSERT OVERWRITE TABLE countries
-SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
+SELECT * FROM json.`s3a://area-for-iomete/countries.json`;
 ```
 
-- **Option 3. Merge with existing data**
+### Option 3: Merge by Key
+
+When you need to insert new rows and update changed ones in a single pass, reach for `MERGE INTO`. The example below assumes both the target table and the source file have an `id` column:
 
 ```sql
 MERGE INTO countries
-    USING (SELECT  * FROM json.`s3a://area-for-iomete/countries.json`) updates
+    USING (SELECT * FROM json.`s3a://area-for-iomete/countries.json`) updates
 ON countries.id = updates.id
 WHEN MATCHED THEN
     UPDATE SET *
@@ -93,42 +103,42 @@ WHEN NOT MATCHED
     THEN INSERT *;
 ```
 
-### Partitioned Table
+`MERGE INTO` ships with the Iceberg Spark extensions, which IOMETE loads on every Spark session.
 
-Partitioning data to speed up queries or DML that have predicates involving the partition columns. Here we use `country_code` as a partition column
+## Step 3: Working With Partitioned Tables
 
-- **Option 1. Create a partitioned table from select**
+Partitioning a table speeds up any query or DML statement that filters on the partition columns. The three patterns from Step 2 still apply. You just add `PARTITIONED BY (...)` to the target and an `ORDER BY <partition_col>` to the source query. That `ORDER BY` keeps each partition in a single file, which improves write performance and avoids the small-file problem.
 
-```sql SQL
--- Create a partitioned table directly from the query
+**Option 1: Partitioned CTAS**
+
+```sql
 CREATE TABLE countries_partitioned
   PARTITIONED BY (country_code)
 AS SELECT * FROM json.`s3a://area-for-iomete/countries.json`
 ORDER BY country_code;
 
--- To inspect the table use the following query
 DESC TABLE EXTENDED countries_partitioned;
 ```
 
-- **Option 2. Insert into to existing table**
+**Option 2: Insert into an existing partitioned table**
 
-```sql SQL
--- just append data
+```sql
+-- Append
 INSERT INTO countries_partitioned
-  SELECT  * FROM json.`s3a://area-for-iomete/countries.json`
+  SELECT * FROM json.`s3a://area-for-iomete/countries.json`
   ORDER BY country_code;
 
--- or you can use the following command to overwerite data
+-- Overwrite
 INSERT OVERWRITE TABLE countries_partitioned
-  SELECT  * FROM json.`s3a://area-for-iomete/countries.json`
+  SELECT * FROM json.`s3a://area-for-iomete/countries.json`
   ORDER BY country_code;
 ```
 
-- **Option 3. Merge with existing data**
+**Option 3: Merge into a partitioned table**
 
 ```sql
 MERGE INTO countries_partitioned
-  USING (SELECT  * FROM json.`s3a://area-for-iomete/countries.json`) updates
+  USING (SELECT * FROM json.`s3a://area-for-iomete/countries.json`) updates
 ON countries_partitioned.id = updates.id
 WHEN MATCHED THEN
   UPDATE SET *
@@ -136,6 +146,9 @@ WHEN NOT MATCHED
   THEN INSERT *;
 ```
 
-## Conclusion
+Iceberg tracks partition metadata for you, so partition pruning kicks in automatically during the merge.
 
-It's extremly easy to query files in AWS S3 with IOMETE. You just need to provide the bucket name and the path to the file you want to query.
+## Next Steps
+
+- For the longer-form `CREATE TABLE ... USING csv|json|parquet|orc OPTIONS(path "s3a://...")` syntax and per-format options, see [Query Federation](../../reference/sql-quick-start/query-federation.md).
+

--- a/docs/tutorials/aws/read-files-from-aws-s3.md
+++ b/docs/tutorials/aws/read-files-from-aws-s3.md
@@ -1,101 +1,72 @@
 ---
 slug: /aws/read-files-from-aws-s3
 title: Querying Files in AWS S3
-description: Read CSV, JSON, Parquet, and ORC files directly from an external S3 bucket with IOMETE SQL, then move that data into managed Iceberg tables in the Lakehouse.
-sidebar_label: Read Files from S3
+description: Querying Files in AWS S3 with IOMETE. This is an end-to-end guide about how to query and move files from your AWS S3 to IOMETE
 last_update:
-  date: 04/29/2026
-  author: Sourabh Jajoria
+  date: 05/04/2023
 ---
 
 import Img from '@site/src/components/Img';
 
-## Introduction
 
-Most data teams keep raw files in S3 long before they're ready to land in a curated table. This tutorial walks you through querying those files in place from the IOMETE SQL Editor, then promoting the data into managed Iceberg tables in the IOMETE Lakehouse when you're ready. Every example uses standard Spark SQL (no custom IOMETE syntax), so the same queries run from a SQL Editor worksheet, a Spark Job, or a Jupyter notebook.
+This is an end-to-end guide about how to move files from your AWS S3 to IOMETE.
 
-:::info
-The examples assume you have an external bucket called `area-for-iomete` containing a `countries.json` file. Replace the bucket and file names with your own.
+:::info Your files in AWS S3
+Let's assume you have an external bucket in AWS S3 with the CSV files you want to query in IOMETE. In this example, we will use the `area-for-iomete` bucket.
 :::
 
-## Common Use Cases
+## Provide permissions to IOMETE
 
-The patterns below cover the situations where reading directly from S3 saves you a round trip through ingestion tooling:
+In order to access files in this external S3 bucket, IOMETE requires permissions to read/write the files. Follow [this guide](/user-guide/aws/s3-bucket-permissions) to provide the necessary permissions.
 
-- Exploring ad-hoc CSV, JSON, Parquet, or ORC files in S3 without registering them as tables first.
-- Bulk-loading data from an external bucket into the Lakehouse with `CREATE TABLE AS SELECT`.
-- Appending or merging incremental file drops into an existing managed Iceberg table.
+## Querying files in AWS S3
 
-## Prerequisites
-
-IOMETE needs permission to read the bucket before any of these queries work. The ingestion examples later in this tutorial also need write access. Follow the [AWS S3 Buckets Access](/user-guide/aws/s3-bucket-permissions) guide to update the bucket policy and the IOMETE Lakehouse IAM role.
+It's extremely easy to query files in AWS S3 with IOMETE. You just need to provide the bucket name and the path to the file you want to query.
 
 :::info Use the `s3a://` Scheme
 Always reference S3 paths with `s3a://`, not `s3://` or `s3n://`. IOMETE's Spark runtime registers only the Hadoop S3A driver, so `s3://` raises `No FileSystem for scheme: s3`.
 :::
 
-## Step 1: Querying a File in S3
-
-The fastest way to inspect a file is to skip the table registration step entirely and let Spark read it directly. Open the **SQL Editor** in your domain and use the file-format shorthand `<format>.\`<path>\``, where `<format>` is one of `csv`, `json`, `parquet`, or `orc`.
-
 ```sql
-SELECT * FROM json.`s3a://area-for-iomete/countries.json`;
+SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
 ```
 
-The same pattern works for other formats:
+For per-format configuration options (CSV, JSON, Parquet, ORC), see [Query Federation](../../reference/sql-quick-start/query-federation.md).
 
-```sql
-SELECT * FROM csv.`s3a://area-for-iomete/sales.csv`;
-SELECT * FROM parquet.`s3a://area-for-iomete/events.parquet`;
-SELECT * FROM orc.`s3a://area-for-iomete/logs/`;
-```
+## Moving data into the lakehouse
 
-Nothing gets created in the catalog. Spark reads the file on the fly and streams the rows back to the editor.
+If you want to move files to IOMETE Lakehouse, which provides a managed data lake experience, you can use the following commands to create tables and insert data into them.
 
-{/* SCREENSHOT NEEDED: SQL Editor with the json.`s3a://...` query and result rows. */}
+### Non-partitioned Table
 
-## Step 2: Moving Data Into the Lakehouse
+- **Option 1. Create a table from select**
 
-Reading in place is great for exploration, but you'll usually want the data in a managed Iceberg table for downstream queries, governance, and time travel. Three patterns cover almost every ingestion scenario. Pick the one that matches what you need.
-
-### Option 1: Create a Table From the Query
-
-Use `CREATE TABLE AS SELECT` (CTAS) to spin up a fresh managed table populated with the file's rows:
-
-```sql
--- Create a managed Iceberg table directly from the query
+```sql SQL
+-- Create table directly from the query
 CREATE TABLE countries
-AS SELECT * FROM json.`s3a://area-for-iomete/countries.json`;
+AS SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
 
--- Inspect the resulting schema, location, and table properties
+-- To inspect the table use the following query
 DESC TABLE EXTENDED countries;
 ```
 
-:::info
-`CREATE TABLE` produces an Iceberg table by default. IOMETE sets `spark.sql.sources.default = iceberg` globally, so you don't need a `USING iceberg` clause.
-:::
-
-### Option 2: Insert Into an Existing Table
-
-If the target table already exists, append new rows or replace all of them:
+- **Option 2. Insert into to existing table**
 
 ```sql
--- Append rows
+-- just append data
 INSERT INTO countries
-SELECT * FROM json.`s3a://area-for-iomete/countries.json`;
+SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
 
--- Replace all rows atomically
+-- first clean an existing data and then insert new data
 INSERT OVERWRITE TABLE countries
-SELECT * FROM json.`s3a://area-for-iomete/countries.json`;
+SELECT  * FROM json.`s3a://area-for-iomete/countries.json`;
 ```
 
-### Option 3: Merge by Key
-
-When you need to insert new rows and update changed ones in a single pass, reach for `MERGE INTO`. The example below assumes both the target table and the source file have an `id` column:
+- **Option 3. Merge with existing data**
 
 ```sql
 MERGE INTO countries
-    USING (SELECT * FROM json.`s3a://area-for-iomete/countries.json`) updates
+    USING (SELECT  * FROM json.`s3a://area-for-iomete/countries.json`) updates
 ON countries.id = updates.id
 WHEN MATCHED THEN
     UPDATE SET *
@@ -103,42 +74,42 @@ WHEN NOT MATCHED
     THEN INSERT *;
 ```
 
-`MERGE INTO` ships with the Iceberg Spark extensions, which IOMETE loads on every Spark session.
+### Partitioned Table
 
-## Step 3: Working With Partitioned Tables
+Partitioning data to speed up queries or DML that have predicates involving the partition columns. Here we use `country_code` as a partition column
 
-Partitioning a table speeds up any query or DML statement that filters on the partition columns. The three patterns from Step 2 still apply. You just add `PARTITIONED BY (...)` to the target and an `ORDER BY <partition_col>` to the source query. That `ORDER BY` keeps each partition in a single file, which improves write performance and avoids the small-file problem.
+- **Option 1. Create a partitioned table from select**
 
-**Option 1: Partitioned CTAS**
-
-```sql
+```sql SQL
+-- Create a partitioned table directly from the query
 CREATE TABLE countries_partitioned
   PARTITIONED BY (country_code)
 AS SELECT * FROM json.`s3a://area-for-iomete/countries.json`
 ORDER BY country_code;
 
+-- To inspect the table use the following query
 DESC TABLE EXTENDED countries_partitioned;
 ```
 
-**Option 2: Insert into an existing partitioned table**
+- **Option 2. Insert into to existing table**
 
-```sql
--- Append
+```sql SQL
+-- just append data
 INSERT INTO countries_partitioned
-  SELECT * FROM json.`s3a://area-for-iomete/countries.json`
+  SELECT  * FROM json.`s3a://area-for-iomete/countries.json`
   ORDER BY country_code;
 
--- Overwrite
+-- or you can use the following command to overwerite data
 INSERT OVERWRITE TABLE countries_partitioned
-  SELECT * FROM json.`s3a://area-for-iomete/countries.json`
+  SELECT  * FROM json.`s3a://area-for-iomete/countries.json`
   ORDER BY country_code;
 ```
 
-**Option 3: Merge into a partitioned table**
+- **Option 3. Merge with existing data**
 
 ```sql
 MERGE INTO countries_partitioned
-  USING (SELECT * FROM json.`s3a://area-for-iomete/countries.json`) updates
+  USING (SELECT  * FROM json.`s3a://area-for-iomete/countries.json`) updates
 ON countries_partitioned.id = updates.id
 WHEN MATCHED THEN
   UPDATE SET *
@@ -146,9 +117,6 @@ WHEN NOT MATCHED
   THEN INSERT *;
 ```
 
-Iceberg tracks partition metadata for you, so partition pruning kicks in automatically during the merge.
+## Conclusion
 
-## Next Steps
-
-- For the longer-form `CREATE TABLE ... USING csv|json|parquet|orc OPTIONS(path "s3a://...")` syntax and per-format options, see [Query Federation](../../reference/sql-quick-start/query-federation.md).
-
+It's extremly easy to query files in AWS S3 with IOMETE. You just need to provide the bucket name and the path to the file you want to query.

--- a/docs/tutorials/aws/read-files-from-aws-s3.md
+++ b/docs/tutorials/aws/read-files-from-aws-s3.md
@@ -28,7 +28,7 @@ In order to access files in this external S3 bucket, IOMETE requires permissions
 It's extremely easy to query files in AWS S3 with IOMETE. You just need to provide the bucket name and the path to the file you want to query.
 
 :::info Use the `s3a://` Scheme
-Always reference S3 paths with `s3a://`, not `s3://` or `s3n://`. IOMETE's Spark runtime registers only the Hadoop S3A driver, so `s3://` raises `No FileSystem for scheme: s3`.
+Always reference S3 paths with `s3a://`, not `s3://` or `s3n://`. IOMETE's Spark runtime only supports the `s3a://` scheme, so `s3://` raises `No FileSystem for scheme: s3`.
 :::
 
 ```sql

--- a/user-guide/aws/s3-bucket-permissions.md
+++ b/user-guide/aws/s3-bucket-permissions.md
@@ -1,75 +1,53 @@
 ---
 title: AWS S3 Buckets Access
 sidebar_label: S3 Buckets Access
-description: Learn how to provide access to external S3 buckets in IOMETE, a hybrid (cloud & on-premises based) data platform for data storage and analysis. This guide outlines simple steps to connect to S3 buckets and grant permission to the Lakehouse role.
+description: Learn how S3 bucket access works for IOMETE data planes on AWS and outside AWS, and how to grant the right permissions.
 last_update:
-  date: 05/05/2024
-  author: Vusal Dadalov
+  date: 04/28/2026
+  author: Sourabh Jajoria
 ---
 
-IOMETE is a hybrid (cloud & on-premises) platform that allows users to store, manage, and analyze large amounts of data.
-One of the key features of IOMETE is the ability to connect any S3 buckets and access data from them.
+How IOMETE accesses S3 depends on where your data plane runs.
 
-In order to do this, you need to provide permission to the `Lakehouse Role`.
+**On AWS**, the Lakehouse Spark pods run under the Kubernetes service account `lakehouse-service-account`, which is annotated with an IAM role ARN. The EKS OIDC provider federates that Kubernetes identity to an AWS IAM role (IRSA), so pods can access S3 without static credentials. To find your Lakehouse Role ARN, go to **Console > Settings > Data Plane > General**.
 
-:::info
-To find the Lakehouse role, go to the IOMETE **Console > Settings > Data Plane > General** and look for
-the `Lakehouse Role ARN` field.
-:::
+**Outside AWS** (MinIO, Dell ECS, on-prem), the data plane uses static access/secret keys pointed at the S3-compatible service endpoint (e.g. `http://minio.my-cluster:9000`). These credentials cannot authenticate against AWS S3 — the rest of this page applies to AWS deployments only.
 
-:::info `What is the Lakehouse Role?`
-The Lakehouse role is an AWS IAM role that is used by IOMETE Data Plane compute resources to access external S3 buckets.
-The Lakehouse role is created during the IOMETE Data Plane installation process.
-:::
+## Granting Access to an External S3 Bucket (AWS)
 
-## Options to provide access to S3 buckets
+There are two ways to grant the Lakehouse role access to an external bucket:
 
-AWS provides essentially two ways to provide access to S3 buckets:
+1. **[Bucket Policy](#bucket-policy)** — add a policy on the external bucket that allows the Lakehouse role as a principal. No IAM console access required.
+2. **[IAM Role Policy](#iam-role-policy)** — attach a policy directly to the Lakehouse role. Requires IAM console access.
 
-1. [Bucket Policy](#bucket-policy): You can create a bucket policy that allows access to the S3 bucket from the
-   Lakehouse role.
-2. [IAM Role Policy](#iam-role-policy): You can create an IAM role policy that allows access to the S3 bucket and attach
-   it to the Lakehouse role.
+Both methods use the same set of S3 actions. For read-only access, only `s3:GetObject` and `s3:ListBucket` are needed.
 
 ---
 
 ## Bucket Policy
 
-The easiest way to grant access to the Lakehouse role is to create a bucket policy that allows the role to access the
-bucket. Since the Lakehouse clusters, Spark jobs, and notebooks are all running under the Lakehouse role, you only need
-to provide access to the Lakehouse role.
+1. Go to your [S3 console](https://s3.console.aws.amazon.com/s3/home) and select your bucket.
+2. Click **Permissions → Bucket Policy**.
+3. Paste one of the examples below, replacing `<lakehouse_role>` with the Lakehouse Role ARN and `<your_bucket>` with your bucket name.
+4. Click **Save**.
 
-To set the bucket policy, you need to navigate to your S3 bucket's permissions page.
+### Full read/write access
 
-1. Go to your [S3 console](https://s3.console.aws.amazon.com/s3/home) and select your desired bucket.
-2. Click on the "Permissions" tab, and then click on "Bucket Policy".
-3. Copy and paste the appropriate policy from the examples below into the bucket policy editor.
-4. Replace `<lakehouse_role>` with the name of your Lakehouse role, and `<your_bucket>` with the name of your S3 bucket.
-5. Click on "Save".
-
-Once saved, you should see a message at the top of the page that says "Bucket policy has been updated." You have now
-successfully granted access to your external S3 bucket for your Lakehouse role!
-
-### Example 1. Full read/write access to your bucket from Lakehouse role:
-
-Let's say you have a bucket called `my-bucket` and you want to give access to the Lakehouse role. You can create a
-bucket policy that looks like this. Replace `<lakehouse_role>` with the Lakehouse role and `<your_bucket>` with the name
-of your bucket.
-
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": {
-                "AWS": [
-                    "<lakehouse_role>"
-                ]
-            },
+            "Principal": { "AWS": ["<lakehouse_role>"] },
             "Action": [
-                "s3:*Object",
-                "s3:ListBucket"
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
             ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
@@ -80,25 +58,16 @@ of your bucket.
 }
 ```
 
-This policy provides full read/write access to your bucket from the Lakehouse role.
+### Read-only access
 
-### Example 2. Read-only access to your bucket from Lakehouse role:
-
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": {
-                "AWS": [
-                    "<lakehouse_role>"
-                ]
-            },
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
+            "Principal": { "AWS": ["<lakehouse_role>"] },
+            "Action": ["s3:GetObject", "s3:ListBucket"],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -108,26 +77,18 @@ This policy provides full read/write access to your bucket from the Lakehouse ro
 }
 ```
 
-Only the highlighted line is different from the previous policy.
-This policy provides read-only access to your bucket from the Lakehouse role.
+### Read-only access to a specific folder
 
-### Example 3. Read-only access to a specific folder in your bucket from Lakehouse role:
+Replace `folder` with your prefix.
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": {
-                "AWS": [
-                    "<lakehouse_role>"
-                ]
-            },
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
+            "Principal": { "AWS": ["<lakehouse_role>"] },
+            "Action": ["s3:GetObject", "s3:ListBucket"],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/folder/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -136,48 +97,37 @@ This policy provides read-only access to your bucket from the Lakehouse role.
     ]
 }
 ```
-
-See highlighted lines for the difference from the previous policy. This policy provides read-only access to a specific
-folder in your bucket from the Lakehouse role.
 
 ---
 
 ## IAM Role Policy
 
-Another way to provide access to the Lakehouse role is to create an IAM role policy that allows access to the S3 bucket
-and attach it to the Lakehouse role.
-
-### Attaching the IAM Role Policy
-
-To attach the IAM role policy to the Lakehouse role, you need to navigate to the IAM console.
-
-1. Go to your [IAM console](https://console.aws.amazon.com/iam/home) and select `Roles` from the left-hand menu.
-2. Search for the Lakehouse role in the list of roles and click on it.
-3. Click on the Permissions tab, and then click on Add `inline policy`.
-4. See below for the examples to create a policy. You can copy and paste the policy into the JSON editor.
-5. Click on `Review policy`. Give your policy a name and click on `Create policy`.
-
-You have now successfully attached the IAM role policy to the Lakehouse role. You can now use the Lakehouse role to
-access the S3 bucket from IOMETE.
+1. Go to your [IAM console](https://console.aws.amazon.com/iam/home) and select **Roles**.
+2. Search for the Lakehouse role and click it.
+3. Click **Permissions → Add inline policy**, paste one of the examples below, and save.
 
 :::note
-Alternative to `Inline policy`, you can also create a `Managed policy` from `Policies` in the IAM console and attach it
-to the Lakehouse role.
+You can also create a **Managed policy** under **Policies** and attach it to the Lakehouse role instead.
 :::
 
-Here are some examples of IAM role policies that you can attach to the Lakehouse role:
+IAM role policies do not include a `Principal` field — the policy is scoped to the role it's attached to.
 
-### Example 1. Full read/write access to your bucket:
+### Full read/write access
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
             "Action": [
-                "s3:*Object",
-                "s3:ListBucket"
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
             ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
@@ -188,25 +138,15 @@ Here are some examples of IAM role policies that you can attach to the Lakehouse
 }
 ```
 
-Replace `<your_bucket>` with the name of your S3 bucket that you want to provide access to.
+### Read-only access
 
-:::info
-You already noticed that, IAM role policy does not require to specify the `Principal` field as it is already attached to
-the Lakehouse role.
-:::
-
-### Example 2. Read-only access to your bucket:
-
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
+            "Action": ["s3:GetObject", "s3:ListBucket"],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -216,20 +156,15 @@ the Lakehouse role.
 }
 ```
 
-Only the highlighted line is different from the previous policy.
+### Read-only access to a specific folder
 
-### Example 3. Read-only access to a specific folder in your bucket:
-
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
+            "Action": ["s3:GetObject", "s3:ListBucket"],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/folder/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -239,13 +174,6 @@ Only the highlighted line is different from the previous policy.
 }
 ```
 
-See highlighted lines for the difference from the previous policy.
-
 :::info
-In the `Resource` field, you can specify multiple resources by separating them with a comma do provide access to
-multiple buckets or folders.
+To grant access to multiple buckets or folders, add additional entries to the `Resource` array.
 :::
-
----
-If you have any questions or need further assistance, please feel free to reach out to our support team. We are always
-here to help you with any questions or issues you may have.

--- a/user-guide/aws/s3-bucket-permissions.md
+++ b/user-guide/aws/s3-bucket-permissions.md
@@ -3,8 +3,8 @@ title: AWS S3 Buckets Access
 sidebar_label: S3 Buckets Access
 description: Learn how to provide access to external S3 buckets in IOMETE, a hybrid (cloud & on-premises based) data platform for data storage and analysis. This guide outlines simple steps to connect to S3 buckets and grant permission to the Lakehouse role.
 last_update:
-  date: 05/05/2024
-  author: Vusal Dadalov
+  date: 04/29/2026
+  author: Sourabh Jajoria
 ---
 
 IOMETE is a hybrid (cloud & on-premises) platform that allows users to store, manage, and analyze large amounts of data.
@@ -17,9 +17,12 @@ To find the Lakehouse role, go to the IOMETE **Console > Settings > Data Plane >
 the `Lakehouse Role ARN` field.
 :::
 
-:::info `What is the Lakehouse Role?`
-The Lakehouse role is an AWS IAM role that is used by IOMETE Data Plane compute resources to access external S3 buckets.
-The Lakehouse role is created during the IOMETE Data Plane installation process.
+:::info What is the Lakehouse Role?
+The Lakehouse role is an AWS IAM role used by IOMETE Data Plane compute resources (Spark driver and executor pods) to access S3. On AWS, it works via IRSA — the pods run under the `lakehouse-service-account` Kubernetes service account, which is annotated with the role ARN so AWS automatically issues temporary credentials. The Lakehouse role is created during the IOMETE Data Plane installation process.
+:::
+
+:::note Running IOMETE outside AWS?
+If your data plane runs on-prem with MinIO, Dell ECS, or another S3-compatible store, the Lakehouse role does not apply. S3 access uses static access/secret keys and an endpoint URL configured in the data plane Helm values — there is no IAM role to update. The rest of this page covers AWS deployments only.
 :::
 
 ## Options to provide access to S3 buckets
@@ -56,7 +59,7 @@ Let's say you have a bucket called `my-bucket` and you want to give access to th
 bucket policy that looks like this. Replace `<lakehouse_role>` with the Lakehouse role and `<your_bucket>` with the name
 of your bucket.
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -68,8 +71,13 @@ of your bucket.
                 ]
             },
             "Action": [
-                "s3:*Object",
-                "s3:ListBucket"
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
             ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
@@ -84,7 +92,7 @@ This policy provides full read/write access to your bucket from the Lakehouse ro
 
 ### Example 2. Read-only access to your bucket from Lakehouse role:
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -108,12 +116,11 @@ This policy provides full read/write access to your bucket from the Lakehouse ro
 }
 ```
 
-Only the highlighted line is different from the previous policy.
 This policy provides read-only access to your bucket from the Lakehouse role.
 
 ### Example 3. Read-only access to a specific folder in your bucket from Lakehouse role:
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -137,8 +144,7 @@ This policy provides read-only access to your bucket from the Lakehouse role.
 }
 ```
 
-See highlighted lines for the difference from the previous policy. This policy provides read-only access to a specific
-folder in your bucket from the Lakehouse role.
+This policy provides read-only access to a specific folder in your bucket from the Lakehouse role.
 
 ---
 
@@ -169,15 +175,20 @@ Here are some examples of IAM role policies that you can attach to the Lakehouse
 
 ### Example 1. Full read/write access to your bucket:
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
             "Action": [
-                "s3:*Object",
-                "s3:ListBucket"
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload"
             ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
@@ -197,7 +208,7 @@ the Lakehouse role.
 
 ### Example 2. Read-only access to your bucket:
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -216,11 +227,9 @@ the Lakehouse role.
 }
 ```
 
-Only the highlighted line is different from the previous policy.
-
 ### Example 3. Read-only access to a specific folder in your bucket:
 
-```js showLineNumbers
+```json showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -239,13 +248,9 @@ Only the highlighted line is different from the previous policy.
 }
 ```
 
-See highlighted lines for the difference from the previous policy.
-
 :::info
 In the `Resource` field, you can specify multiple resources by separating them with a comma do provide access to
 multiple buckets or folders.
 :::
 
 ---
-If you have any questions or need further assistance, please feel free to reach out to our support team. We are always
-here to help you with any questions or issues you may have.

--- a/user-guide/aws/s3-bucket-permissions.md
+++ b/user-guide/aws/s3-bucket-permissions.md
@@ -18,11 +18,11 @@ the `Lakehouse Role ARN` field.
 :::
 
 :::info What is the Lakehouse Role?
-The Lakehouse role is an AWS IAM role used by IOMETE Data Plane compute resources (Spark driver and executor pods) to access S3. On AWS, it works via IRSA — the pods run under the `lakehouse-service-account` Kubernetes service account, which is annotated with the role ARN so AWS automatically issues temporary credentials. The Lakehouse role is created during the IOMETE Data Plane installation process.
+The Lakehouse role is an AWS IAM role used by IOMETE Data Plane compute resources (Spark driver and executor pods) to access S3. On AWS, it works via [IRSA (IAM Roles for Service Accounts)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) — the pods run under the [`lakehouse-service-account`](https://kubernetes.io/docs/concepts/security/service-accounts/) Kubernetes service account, which is annotated with the role ARN so AWS automatically issues temporary credentials. The Lakehouse role is created during the IOMETE Data Plane installation process.
 :::
 
 :::note Running IOMETE outside AWS?
-If your data plane runs on-prem with MinIO, Dell ECS, or another S3-compatible store, the Lakehouse role does not apply. S3 access uses static access/secret keys and an endpoint URL configured in the data plane Helm values — there is no IAM role to update. The rest of this page covers AWS deployments only.
+If your data plane runs on-prem with MinIO, Dell ECS, or another S3-compatible store, the AWS IAM role does not apply. S3 access uses static access/secret keys and an endpoint URL configured in the data plane Helm values — there is no IAM role to update. The rest of this page covers AWS deployments only.
 :::
 
 ## Options to provide access to S3 buckets

--- a/user-guide/aws/s3-bucket-permissions.md
+++ b/user-guide/aws/s3-bucket-permissions.md
@@ -1,53 +1,75 @@
 ---
 title: AWS S3 Buckets Access
 sidebar_label: S3 Buckets Access
-description: Learn how S3 bucket access works for IOMETE data planes on AWS and outside AWS, and how to grant the right permissions.
+description: Learn how to provide access to external S3 buckets in IOMETE, a hybrid (cloud & on-premises based) data platform for data storage and analysis. This guide outlines simple steps to connect to S3 buckets and grant permission to the Lakehouse role.
 last_update:
-  date: 04/28/2026
-  author: Sourabh Jajoria
+  date: 05/05/2024
+  author: Vusal Dadalov
 ---
 
-How IOMETE accesses S3 depends on where your data plane runs.
+IOMETE is a hybrid (cloud & on-premises) platform that allows users to store, manage, and analyze large amounts of data.
+One of the key features of IOMETE is the ability to connect any S3 buckets and access data from them.
 
-**On AWS**, the Lakehouse Spark pods run under the Kubernetes service account `lakehouse-service-account`, which is annotated with an IAM role ARN. The EKS OIDC provider federates that Kubernetes identity to an AWS IAM role (IRSA), so pods can access S3 without static credentials. To find your Lakehouse Role ARN, go to **Console > Settings > Data Plane > General**.
+In order to do this, you need to provide permission to the `Lakehouse Role`.
 
-**Outside AWS** (MinIO, Dell ECS, on-prem), the data plane uses static access/secret keys pointed at the S3-compatible service endpoint (e.g. `http://minio.my-cluster:9000`). These credentials cannot authenticate against AWS S3 — the rest of this page applies to AWS deployments only.
+:::info
+To find the Lakehouse role, go to the IOMETE **Console > Settings > Data Plane > General** and look for
+the `Lakehouse Role ARN` field.
+:::
 
-## Granting Access to an External S3 Bucket (AWS)
+:::info `What is the Lakehouse Role?`
+The Lakehouse role is an AWS IAM role that is used by IOMETE Data Plane compute resources to access external S3 buckets.
+The Lakehouse role is created during the IOMETE Data Plane installation process.
+:::
 
-There are two ways to grant the Lakehouse role access to an external bucket:
+## Options to provide access to S3 buckets
 
-1. **[Bucket Policy](#bucket-policy)** — add a policy on the external bucket that allows the Lakehouse role as a principal. No IAM console access required.
-2. **[IAM Role Policy](#iam-role-policy)** — attach a policy directly to the Lakehouse role. Requires IAM console access.
+AWS provides essentially two ways to provide access to S3 buckets:
 
-Both methods use the same set of S3 actions. For read-only access, only `s3:GetObject` and `s3:ListBucket` are needed.
+1. [Bucket Policy](#bucket-policy): You can create a bucket policy that allows access to the S3 bucket from the
+   Lakehouse role.
+2. [IAM Role Policy](#iam-role-policy): You can create an IAM role policy that allows access to the S3 bucket and attach
+   it to the Lakehouse role.
 
 ---
 
 ## Bucket Policy
 
-1. Go to your [S3 console](https://s3.console.aws.amazon.com/s3/home) and select your bucket.
-2. Click **Permissions → Bucket Policy**.
-3. Paste one of the examples below, replacing `<lakehouse_role>` with the Lakehouse Role ARN and `<your_bucket>` with your bucket name.
-4. Click **Save**.
+The easiest way to grant access to the Lakehouse role is to create a bucket policy that allows the role to access the
+bucket. Since the Lakehouse clusters, Spark jobs, and notebooks are all running under the Lakehouse role, you only need
+to provide access to the Lakehouse role.
 
-### Full read/write access
+To set the bucket policy, you need to navigate to your S3 bucket's permissions page.
 
-```json showLineNumbers
+1. Go to your [S3 console](https://s3.console.aws.amazon.com/s3/home) and select your desired bucket.
+2. Click on the "Permissions" tab, and then click on "Bucket Policy".
+3. Copy and paste the appropriate policy from the examples below into the bucket policy editor.
+4. Replace `<lakehouse_role>` with the name of your Lakehouse role, and `<your_bucket>` with the name of your S3 bucket.
+5. Click on "Save".
+
+Once saved, you should see a message at the top of the page that says "Bucket policy has been updated." You have now
+successfully granted access to your external S3 bucket for your Lakehouse role!
+
+### Example 1. Full read/write access to your bucket from Lakehouse role:
+
+Let's say you have a bucket called `my-bucket` and you want to give access to the Lakehouse role. You can create a
+bucket policy that looks like this. Replace `<lakehouse_role>` with the Lakehouse role and `<your_bucket>` with the name
+of your bucket.
+
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": { "AWS": ["<lakehouse_role>"] },
+            "Principal": {
+                "AWS": [
+                    "<lakehouse_role>"
+                ]
+            },
             "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject",
-                "s3:ListBucket",
-                "s3:ListBucketMultipartUploads",
-                "s3:ListMultipartUploadParts",
-                "s3:AbortMultipartUpload"
+                "s3:*Object",
+                "s3:ListBucket"
             ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
@@ -58,16 +80,25 @@ Both methods use the same set of S3 actions. For read-only access, only `s3:GetO
 }
 ```
 
-### Read-only access
+This policy provides full read/write access to your bucket from the Lakehouse role.
 
-```json showLineNumbers
+### Example 2. Read-only access to your bucket from Lakehouse role:
+
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": { "AWS": ["<lakehouse_role>"] },
-            "Action": ["s3:GetObject", "s3:ListBucket"],
+            "Principal": {
+                "AWS": [
+                    "<lakehouse_role>"
+                ]
+            },
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -77,18 +108,26 @@ Both methods use the same set of S3 actions. For read-only access, only `s3:GetO
 }
 ```
 
-### Read-only access to a specific folder
+Only the highlighted line is different from the previous policy.
+This policy provides read-only access to your bucket from the Lakehouse role.
 
-Replace `folder` with your prefix.
+### Example 3. Read-only access to a specific folder in your bucket from Lakehouse role:
 
-```json showLineNumbers
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": { "AWS": ["<lakehouse_role>"] },
-            "Action": ["s3:GetObject", "s3:ListBucket"],
+            "Principal": {
+                "AWS": [
+                    "<lakehouse_role>"
+                ]
+            },
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/folder/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -97,37 +136,48 @@ Replace `folder` with your prefix.
     ]
 }
 ```
+
+See highlighted lines for the difference from the previous policy. This policy provides read-only access to a specific
+folder in your bucket from the Lakehouse role.
 
 ---
 
 ## IAM Role Policy
 
-1. Go to your [IAM console](https://console.aws.amazon.com/iam/home) and select **Roles**.
-2. Search for the Lakehouse role and click it.
-3. Click **Permissions → Add inline policy**, paste one of the examples below, and save.
+Another way to provide access to the Lakehouse role is to create an IAM role policy that allows access to the S3 bucket
+and attach it to the Lakehouse role.
+
+### Attaching the IAM Role Policy
+
+To attach the IAM role policy to the Lakehouse role, you need to navigate to the IAM console.
+
+1. Go to your [IAM console](https://console.aws.amazon.com/iam/home) and select `Roles` from the left-hand menu.
+2. Search for the Lakehouse role in the list of roles and click on it.
+3. Click on the Permissions tab, and then click on Add `inline policy`.
+4. See below for the examples to create a policy. You can copy and paste the policy into the JSON editor.
+5. Click on `Review policy`. Give your policy a name and click on `Create policy`.
+
+You have now successfully attached the IAM role policy to the Lakehouse role. You can now use the Lakehouse role to
+access the S3 bucket from IOMETE.
 
 :::note
-You can also create a **Managed policy** under **Policies** and attach it to the Lakehouse role instead.
+Alternative to `Inline policy`, you can also create a `Managed policy` from `Policies` in the IAM console and attach it
+to the Lakehouse role.
 :::
 
-IAM role policies do not include a `Principal` field — the policy is scoped to the role it's attached to.
+Here are some examples of IAM role policies that you can attach to the Lakehouse role:
 
-### Full read/write access
+### Example 1. Full read/write access to your bucket:
 
-```json showLineNumbers
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
             "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject",
-                "s3:ListBucket",
-                "s3:ListBucketMultipartUploads",
-                "s3:ListMultipartUploadParts",
-                "s3:AbortMultipartUpload"
+                "s3:*Object",
+                "s3:ListBucket"
             ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
@@ -138,15 +188,25 @@ IAM role policies do not include a `Principal` field — the policy is scoped to
 }
 ```
 
-### Read-only access
+Replace `<your_bucket>` with the name of your S3 bucket that you want to provide access to.
 
-```json showLineNumbers
+:::info
+You already noticed that, IAM role policy does not require to specify the `Principal` field as it is already attached to
+the Lakehouse role.
+:::
+
+### Example 2. Read-only access to your bucket:
+
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": ["s3:GetObject", "s3:ListBucket"],
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -156,15 +216,20 @@ IAM role policies do not include a `Principal` field — the policy is scoped to
 }
 ```
 
-### Read-only access to a specific folder
+Only the highlighted line is different from the previous policy.
 
-```json showLineNumbers
+### Example 3. Read-only access to a specific folder in your bucket:
+
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": ["s3:GetObject", "s3:ListBucket"],
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::<your_bucket>/folder/*",
                 "arn:aws:s3:::<your_bucket>"
@@ -174,6 +239,13 @@ IAM role policies do not include a `Principal` field — the policy is scoped to
 }
 ```
 
+See highlighted lines for the difference from the previous policy.
+
 :::info
-To grant access to multiple buckets or folders, add additional entries to the `Resource` array.
+In the `Resource` field, you can specify multiple resources by separating them with a comma do provide access to
+multiple buckets or folders.
 :::
+
+---
+If you have any questions or need further assistance, please feel free to reach out to our support team. We are always
+here to help you with any questions or issues you may have.

--- a/user-guide/aws/s3-bucket-permissions.md
+++ b/user-guide/aws/s3-bucket-permissions.md
@@ -3,8 +3,8 @@ title: AWS S3 Buckets Access
 sidebar_label: S3 Buckets Access
 description: Learn how to provide access to external S3 buckets in IOMETE, a hybrid (cloud & on-premises based) data platform for data storage and analysis. This guide outlines simple steps to connect to S3 buckets and grant permission to the Lakehouse role.
 last_update:
-  date: 04/29/2026
-  author: Sourabh Jajoria
+  date: 05/05/2024
+  author: Vusal Dadalov
 ---
 
 IOMETE is a hybrid (cloud & on-premises) platform that allows users to store, manage, and analyze large amounts of data.
@@ -59,7 +59,7 @@ Let's say you have a bucket called `my-bucket` and you want to give access to th
 bucket policy that looks like this. Replace `<lakehouse_role>` with the Lakehouse role and `<your_bucket>` with the name
 of your bucket.
 
-```json showLineNumbers
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -92,7 +92,7 @@ This policy provides full read/write access to your bucket from the Lakehouse ro
 
 ### Example 2. Read-only access to your bucket from Lakehouse role:
 
-```json showLineNumbers
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -120,7 +120,7 @@ This policy provides read-only access to your bucket from the Lakehouse role.
 
 ### Example 3. Read-only access to a specific folder in your bucket from Lakehouse role:
 
-```json showLineNumbers
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -175,7 +175,7 @@ Here are some examples of IAM role policies that you can attach to the Lakehouse
 
 ### Example 1. Full read/write access to your bucket:
 
-```json showLineNumbers
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -208,7 +208,7 @@ the Lakehouse role.
 
 ### Example 2. Read-only access to your bucket:
 
-```json showLineNumbers
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -229,7 +229,7 @@ the Lakehouse role.
 
 ### Example 3. Read-only access to a specific folder in your bucket:
 
-```json showLineNumbers
+```js showLineNumbers
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -254,3 +254,5 @@ multiple buckets or folders.
 :::
 
 ---
+If you have any questions or need further assistance, please feel free to reach out to our support team. We are always
+here to help you with any questions or issues you may have.


### PR DESCRIPTION
## Summary

**Tutorial (`docs/tutorials/aws/read-files-from-aws-s3.md`)**
- Add `:::info Use the s3a:// Scheme` callout — missing info explaining why `s3://` raises `No FileSystem for scheme: s3` (validated: Hadoop S3A driver is the only registered filesystem)
- Fix info box: said "CSV files" but every SQL example uses `countries.json` — updated to match

**Permissions page (`user-guide/aws/s3-bucket-permissions.md`)**
- Correct the Lakehouse Role info box — old text omitted the IRSA mechanism; updated to explain pods run under `lakehouse-service-account`, annotated with the role ARN, and AWS issues temporary credentials via OIDC (validated: `variables.tf:34`, `data-plane-helms/values.yaml:1-5`, `main.tf:1-32`)
- Add non-AWS callout — missing info for MinIO/Dell ECS deployments where static keys + endpoint are used and the IAM role does not apply (validated: `SecretService.kt:66-88`, `DataPlane.kt:198-234`)
- Replace `s3:*Object` wildcard with 7 explicit IAM actions — wildcard also matches unintended actions like `s3:RestoreObject`; explicit list matches the Terraform module exactly (validated: `main.tf:34-61`)
- Remove stale "Only the highlighted line is different" / "See highlighted lines" sentences — no line highlighting exists in the rendered doc
