### PR TITLE
Add HTML snapshot gate for dependency-bump PR validation

### DIFF
--- a/.github/workflows/snapshot-gate.yaml
+++ b/.github/workflows/snapshot-gate.yaml
@@ -1,14 +1,24 @@
 name: Snapshot Gate
 
-# Validates dependency-bump (and other) PRs by building the docs site against
-# both `merge-base(origin/main, HEAD)` and the PR head, normalizing webpack
-# content hashes, and diffing the emitted HTML. Any non-empty diff fails the
-# gate unless the PR carries the `snapshot-acknowledged` label.
+# Validates pure dependency-bump PRs by building the docs site against both
+# `merge-base(origin/main, HEAD)` and the PR head, normalizing webpack content
+# hashes + sourcemap comments + JSON-LD `dateModified`, and diffing the
+# emitted HTML. Any non-empty diff fails unless the PR carries the
+# `snapshot-acknowledged` label.
+#
+# Scope (two filters):
+#   1. `paths:` — workflow only triggers when package.json or yarn.lock changes
+#   2. Runtime scope check — skips with "ℹ️ skipped" status if the PR ALSO
+#      changes any non-dep file (mixed-scope PRs can't be cleanly validated;
+#      split into separate PRs for dep changes vs content changes)
 
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
 
 permissions:
   pull-requests: write
@@ -44,7 +54,30 @@ jobs:
           echo "sha=$BASE" >> "$GITHUB_OUTPUT"
           echo "Base commit: $BASE"
 
+      - name: Check scope (skip if mixed PR)
+        id: scope
+        run: |
+          BASE="${{ steps.base.outputs.sha }}"
+          NON_DEP_FILES=$(git diff --name-only "$BASE..HEAD" \
+            | grep -v -E '^(package\.json|yarn\.lock)$' || true)
+
+          if [ -n "$NON_DEP_FILES" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'non_dep_files<<EOF'
+              echo "$NON_DEP_FILES"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping snapshot gate — PR changes files beyond package.json/yarn.lock"
+            echo "Files outside dep scope:"
+            echo "$NON_DEP_FILES" | sed 's/^/  /'
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Only dep files changed — proceeding with gate."
+          fi
+
       - name: Build base snapshot
+        if: steps.scope.outputs.skip != 'true'
         run: |
           git checkout ${{ steps.base.outputs.sha }}
           rm -rf node_modules build .docusaurus
@@ -53,6 +86,7 @@ jobs:
           mv build build-base
 
       - name: Build PR head snapshot
+        if: steps.scope.outputs.skip != 'true'
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
           rm -rf node_modules build .docusaurus
@@ -61,12 +95,14 @@ jobs:
           mv build build-pr
 
       - name: Normalize both snapshots
+        if: steps.scope.outputs.skip != 'true'
         run: |
           ./scripts/snapshot-normalize.sh build-base
           ./scripts/snapshot-normalize.sh build-pr
 
       - name: Compute diff
         id: diff
+        if: steps.scope.outputs.skip != 'true'
         run: |
           set +e
           diff -r -u build-base build-pr > snapshot-diff.txt 2>&1
@@ -102,7 +138,7 @@ jobs:
           fi
 
       - name: Upload diff artifact
-        if: steps.diff.outputs.status == 'changed'
+        if: steps.scope.outputs.skip != 'true' && steps.diff.outputs.status == 'changed'
         uses: actions/upload-artifact@v4
         with:
           name: snapshot-diff-pr-${{ github.event.pull_request.number }}
@@ -123,6 +159,8 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BASE_SHA="${{ steps.base.outputs.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          SKIP="${{ steps.scope.outputs.skip }}"
+          NON_DEP_FILES="${{ steps.scope.outputs.non_dep_files }}"
           STATUS="${{ steps.diff.outputs.status }}"
           CHANGED="${{ steps.diff.outputs.files_changed }}"
           ACK="${{ steps.override.outputs.acknowledged }}"
@@ -132,7 +170,22 @@ jobs:
             echo "### HTML Snapshot Gate"
             echo ""
 
-            if [ "$STATUS" = "clean" ]; then
+            if [ "$SKIP" = "true" ]; then
+              echo "ℹ️ **Skipped — mixed-scope PR.**"
+              echo ""
+              echo "The gate only validates pure dep-bump PRs (only \`package.json\` and/or \`yarn.lock\` changed). This PR also touches non-dep files, so the gate cannot cleanly attribute HTML diffs to dep changes vs. content changes."
+              echo ""
+              echo "<details>"
+              echo "<summary>Files outside dep scope</summary>"
+              echo ""
+              echo '```'
+              echo "$NON_DEP_FILES"
+              echo '```'
+              echo ""
+              echo "</details>"
+              echo ""
+              echo "If you want this PR's dep changes validated, split into two PRs: one for deps, one for content."
+            elif [ "$STATUS" = "clean" ]; then
               echo "✅ **No HTML changes** — safe to merge."
             elif [ "$ACK" = "true" ]; then
               echo "✅ **${CHANGED} files changed — acknowledged via \`snapshot-acknowledged\` label**."

--- a/.github/workflows/snapshot-gate.yaml
+++ b/.github/workflows/snapshot-gate.yaml
@@ -104,8 +104,17 @@ jobs:
         id: diff
         if: steps.scope.outputs.skip != 'true'
         run: |
+          # Compare HTML/XML/TXT only — exclude webpack-bundled assets and
+          # binaries which legitimately differ between dep bumps even when
+          # the published HTML is unchanged (webpack rehashes chunks, etc.).
+          # The HTML normalizer handles references to those assets.
           set +e
-          diff -r -u build-base build-pr > snapshot-diff.txt 2>&1
+          diff -r -u \
+            -x '*.js' -x '*.map' -x '*.css' \
+            -x '*.png' -x '*.jpg' -x '*.jpeg' -x '*.gif' -x '*.svg' -x '*.ico' -x '*.webp' \
+            -x '*.woff' -x '*.woff2' -x '*.ttf' -x '*.otf' \
+            -x '*.json' \
+            build-base build-pr > snapshot-diff.txt 2>&1
           DIFF_EXIT=$?
           set -e
 
@@ -129,13 +138,11 @@ jobs:
 
       - name: Check label override
         id: override
+        # Use Actions `contains()` for exact array-element match. Substring
+        # matching (e.g., `grep snapshot-acknowledged`) would let a label
+        # like `not-snapshot-acknowledged` bypass the gate.
         run: |
-          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
-          if echo "$LABELS" | grep -q snapshot-acknowledged; then
-            echo "acknowledged=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "acknowledged=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "acknowledged=${{ contains(github.event.pull_request.labels.*.name, 'snapshot-acknowledged') }}" >> "$GITHUB_OUTPUT"
 
       - name: Upload diff artifact
         if: steps.scope.outputs.skip != 'true' && steps.diff.outputs.status == 'changed'
@@ -220,6 +227,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create or update PR comment
+        # Non-blocking: if the workflow lacks `pull-requests: write` (e.g.,
+        # restricted Dependabot token), failing to post the comment must
+        # not turn a clean snapshot gate into a red check.
+        continue-on-error: true
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/snapshot-gate.yaml
+++ b/.github/workflows/snapshot-gate.yaml
@@ -1,0 +1,181 @@
+name: Snapshot Gate
+
+# Validates dependency-bump (and other) PRs by building the docs site against
+# both `merge-base(origin/main, HEAD)` and the PR head, normalizing webpack
+# content hashes, and diffing the emitted HTML. Any non-empty diff fails the
+# gate unless the PR carries the `snapshot-acknowledged` label.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: snapshot-gate-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  snapshot-gate:
+    name: HTML Snapshot Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Determine merge-base
+        id: base
+        run: |
+          BASE=$(git merge-base origin/main HEAD)
+          echo "sha=$BASE" >> "$GITHUB_OUTPUT"
+          echo "Base commit: $BASE"
+
+      - name: Build base snapshot
+        run: |
+          git checkout ${{ steps.base.outputs.sha }}
+          rm -rf node_modules build .docusaurus
+          yarn install --frozen-lockfile --no-progress
+          yarn build
+          mv build build-base
+
+      - name: Build PR head snapshot
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          rm -rf node_modules build .docusaurus
+          yarn install --frozen-lockfile --no-progress
+          yarn build
+          mv build build-pr
+
+      - name: Normalize both snapshots
+        run: |
+          ./scripts/snapshot-normalize.sh build-base
+          ./scripts/snapshot-normalize.sh build-pr
+
+      - name: Compute diff
+        id: diff
+        run: |
+          set +e
+          diff -r -u build-base build-pr > snapshot-diff.txt 2>&1
+          DIFF_EXIT=$?
+          set -e
+
+          if [ $DIFF_EXIT -eq 0 ]; then
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+            echo "files_changed=0" >> "$GITHUB_OUTPUT"
+            echo "✓ No HTML changes"
+          elif [ $DIFF_EXIT -eq 1 ]; then
+            MOD=$(grep -c "^diff " snapshot-diff.txt 2>/dev/null) || true
+            ADDED=$(grep -c "^Only in build-pr" snapshot-diff.txt 2>/dev/null) || true
+            REMOVED=$(grep -c "^Only in build-base" snapshot-diff.txt 2>/dev/null) || true
+            CHANGED=$((MOD + ADDED + REMOVED))
+            echo "status=changed" >> "$GITHUB_OUTPUT"
+            echo "files_changed=$CHANGED" >> "$GITHUB_OUTPUT"
+            echo "✗ $CHANGED files changed (modified=$MOD, added=$ADDED, removed=$REMOVED)"
+          else
+            echo "::error::diff command exited with $DIFF_EXIT — unexpected error"
+            head -50 snapshot-diff.txt
+            exit $DIFF_EXIT
+          fi
+
+      - name: Check label override
+        id: override
+        run: |
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q snapshot-acknowledged; then
+            echo "acknowledged=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "acknowledged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload diff artifact
+        if: steps.diff.outputs.status == 'changed'
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-diff-pr-${{ github.event.pull_request.number }}
+          path: snapshot-diff.txt
+          retention-days: 30
+
+      - name: Find existing comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: '<!-- snapshot-gate -->'
+
+      - name: Build comment body
+        id: comment
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BASE_SHA="${{ steps.base.outputs.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          STATUS="${{ steps.diff.outputs.status }}"
+          CHANGED="${{ steps.diff.outputs.files_changed }}"
+          ACK="${{ steps.override.outputs.acknowledged }}"
+
+          {
+            echo '<!-- snapshot-gate -->'
+            echo "### HTML Snapshot Gate"
+            echo ""
+
+            if [ "$STATUS" = "clean" ]; then
+              echo "✅ **No HTML changes** — safe to merge."
+            elif [ "$ACK" = "true" ]; then
+              echo "✅ **${CHANGED} files changed — acknowledged via \`snapshot-acknowledged\` label**."
+            else
+              echo "❌ **${CHANGED} HTML files changed** — review required before merge."
+              echo ""
+              echo "<details>"
+              echo "<summary>First 200 lines of unified diff</summary>"
+              echo ""
+              echo '```diff'
+              head -n 200 snapshot-diff.txt
+              echo '```'
+              echo ""
+              echo "</details>"
+              echo ""
+              echo "If the diff is expected (e.g. webpack runtime change visible on every page), add the \`snapshot-acknowledged\` label to override the gate."
+            fi
+
+            echo ""
+            echo "Base: \`${BASE_SHA:0:8}\` · Head: \`${HEAD_SHA:0:8}\` · [Workflow run](${RUN_URL})"
+
+            if [ "$STATUS" = "changed" ]; then
+              echo ""
+              echo "Full diff artifact available on the workflow run page (retention: 30 days)."
+            fi
+          } > comment.md
+
+          {
+            echo 'body<<COMMENT_EOF'
+            cat comment.md
+            echo 'COMMENT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.comment.outputs.body }}
+          edit-mode: replace
+
+      - name: Fail if changes not acknowledged
+        if: steps.diff.outputs.status == 'changed' && steps.override.outputs.acknowledged != 'true'
+        run: |
+          echo "::error::Snapshot gate failed — ${{ steps.diff.outputs.files_changed }} HTML files changed without 'snapshot-acknowledged' label"
+          exit 1

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "sharp": "^0.34.5",
     "tailwindcss": "^3.4.19"
   },
+  "//resolutions": "Pinned to patch vulnerable transitive deps that parent packages still pull at insecure versions. See PRs #380 (picomatch) and #383 (the other 7) for the original Dependabot alerts each entry addresses. Don't remove an entry without confirming the parent no longer needs the vulnerable version — check with `yarn why <pkg>`.",
   "resolutions": {
     "**/@parcel/watcher/picomatch": "^4.0.4",
     "**/picomatch": "^2.3.2",

--- a/scripts/snapshot-normalize.sh
+++ b/scripts/snapshot-normalize.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# snapshot-normalize.sh — strip build-to-build non-determinism from a Docusaurus
+# build directory so that two identical builds diff to empty.
+#
+# Three passes:
+#   1. Webpack content hashes:   `main.a1b2c3d4.js` → `main.HASH.js`
+#   2. Sourcemap URL comments:   `//# sourceMappingURL=...` lines deleted
+#   3. JSON-LD `dateModified`:   build-time ISO timestamp → `NORMALIZED`
+#      (Docusaurus injects build-time `dateModified` into schema.org metadata
+#       in <script type="application/ld+json"> blocks on doc pages)
+#
+# Used by .github/workflows/snapshot-gate.yaml to prepare base and head
+# builds for `diff -r`. Idempotent — safe to re-run on the same directory.
+set -euo pipefail
+
+DIR="${1:?usage: snapshot-normalize.sh <build-dir>}"
+
+if [ ! -d "$DIR" ]; then
+  echo "Error: $DIR is not a directory" >&2
+  exit 1
+fi
+
+# Normalize HTML files in place. `-i.bak` form works on both BSD (macOS) and
+# GNU (Linux) sed. `-exec ... {} +` batches files per sed invocation.
+find "$DIR" -type f -name "*.html" -exec sed -i.bak \
+  -e 's/\.[a-f0-9]\{8,20\}\.\(js\|css\|map\)/.HASH.\1/g' \
+  -e '/^\/\/[#@] sourceMappingURL=/d' \
+  -e 's/"dateModified":"[^"]*"/"dateModified":"NORMALIZED"/g' \
+  {} +
+
+# Clean up sed backup files
+find "$DIR" -type f -name "*.html.bak" -delete
+
+# Report
+count=$(find "$DIR" -type f -name "*.html" | wc -l | tr -d ' ')
+echo "Normalized $count HTML files in $DIR"


### PR DESCRIPTION
## Summary

Adds an HTML snapshot gate workflow that automatically validates dependency-bump PRs by comparing the emitted Docusaurus HTML output before and after the bump.

## How it works

On every PR (including `labeled`/`unlabeled` events):
1. Build `base = git merge-base origin/main HEAD`
2. Build PR head
3. Normalize both — strip webpack content hashes, sourcemap comments, and build-time `dateModified` (Docusaurus injects this into JSON-LD on every build, even with identical source)
4. `diff -r -u build-base build-pr`
5. Empty diff → ✅ pass
6. Diff + `snapshot-acknowledged` label → ✅ pass (human ack'd)
7. Diff + no label → ❌ fail (block merge)

PR comments are sticky (updated in place via `peter-evans/find-comment` + `create-or-update-comment`). Full diff uploaded as a workflow artifact (30-day retention).

## Why

We had 12 dep-bump PRs sitting open, most obsolete but 2 still live (#305 mdast-util-to-hast, #306 webpack). The gate gives us a deterministic, fast way to validate these and future bumps without relying on reviewer eyeballs across hundreds of HTML files.

## Local dry-run results

- 478 HTML files built × 2 identical commits
- Pre-normalize diff: 2976 lines (all from `dateModified` JSON-LD timestamps)
- Post-normalize diff: **empty** ✓
- Inverse test (inject a title change in one file): diff catches it ✓

## What's in this PR

- `.github/workflows/snapshot-gate.yaml` — workflow definition
- `scripts/snapshot-normalize.sh` — three-pass regex normalization (hashes, sourcemap comments, dateModified)
- `package.json` — documents the `resolutions` block with a `//resolutions` sibling key pointing to PRs #380, #383

## Rollout (after merge)

1. Open 2 synthetic test PRs (real change + label override) to validate failure path and override mechanism
2. Run gate on #305 and #306 in shadow mode (workflow runs, not yet required check)
3. Add to branch protection as required check

## Notes

- Workflow uses `pull_request` not `pull_request_target` — if comment posting fails on Dependabot PRs, repo setting "Allow GitHub Actions to create and approve PRs" needs to be enabled
- This PR itself is the first integration test — the workflow runs on its own PR. Expected: empty diff (no docs files changed), gate ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)