### PR TITLE
Raise Node heap to 6 GB for snapshot gate builds

### DIFF
--- a/.github/workflows/snapshot-gate.yaml
+++ b/.github/workflows/snapshot-gate.yaml
@@ -82,6 +82,11 @@ jobs:
         # still posts a clear sticky comment instead of just a red check.
         continue-on-error: true
         if: steps.scope.outputs.skip != 'true'
+        # NODE_OPTIONS raises Node's max heap to 6 GB. Default ~4 GB was
+        # hit (FATAL: heap out of memory) when running two Docusaurus
+        # builds back-to-back on the standard 7 GB Ubuntu runner.
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
         run: |
           git checkout ${{ steps.base.outputs.sha }}
           rm -rf node_modules build .docusaurus
@@ -95,6 +100,8 @@ jobs:
         # still posts a clear sticky comment instead of just a red check.
         continue-on-error: true
         if: steps.scope.outputs.skip != 'true'
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
           rm -rf node_modules build .docusaurus


### PR DESCRIPTION
## Summary

Adds `NODE_OPTIONS=--max-old-space-size=6144` to both build steps of the snapshot gate workflow. The gate runs two Docusaurus production builds back-to-back on a single runner; the default Node max heap (~4 GB) was exhausted on the second build, producing a misleading red check.

## How this was surfaced

While running the snapshot gate on #306 (webpack 5.95 → 5.105, after Docusaurus 3.10.1 landed via #427), the head build failed with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

The standalone `build-check` workflow (which only does a single build on a fresh runner) **passed** on the same commit, confirming this was a gate-specific resource issue and not a dep incompatibility.

## Why this only started failing now

Each Docusaurus 3.10.1 production build is heavier than 3.9.2 (new mdx1Compat machinery, plugin-content-blog scale changes). The gate already runs **two** builds in sequence — the OOM emerged when 2× the per-build footprint crossed the default heap ceiling.

## Why not split into separate jobs

Cleaner architecturally, but introduces artifact passing + workflow complexity. We discussed this as a future refactor (separate jobs + build-check artifact reuse). For now, a 1-line env var fix is enough; if memory pressure returns, the multi-job refactor is the next step.

## Testing

No local repro possible — this is a runner-level resource issue. The fix will be validated by:

1. Merging this PR
2. Re-rebasing #306 (webpack bump) — the gate should now complete both builds
3. Expecting either empty diff or a page-uniform webpack-runtime delta (label-ack territory)

## What's in this PR

- `.github/workflows/snapshot-gate.yaml`: add `env: NODE_OPTIONS: --max-old-space-size=6144` to both `Build base snapshot` and `Build PR head snapshot` steps

Only the workflow file changes; the gate path filter excludes itself from running on this PR (no `package.json`/`yarn.lock` change). The existing `build-check` will validate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)