### PR TITLE
Exclude assets/ from gate diff + drop misleading 'HTML' qualifier

### DIFF
--- a/.github/workflows/snapshot-gate.yaml
+++ b/.github/workflows/snapshot-gate.yaml
@@ -125,13 +125,17 @@ jobs:
           && steps.build_base.outcome == 'success'
           && steps.build_head.outcome == 'success'
         run: |
-          # Compare HTML/XML/TXT only — exclude webpack-bundled assets and
-          # binaries which legitimately differ between dep bumps even when
-          # the published HTML is unchanged (webpack rehashes chunks, etc.).
-          # The HTML normalizer handles references to those assets.
+          # Compare user-facing artifacts only. Exclude:
+          #   - `assets/`: webpack output (JS/CSS chunks, LICENSE.txt files,
+          #     source maps) — rehashes on every dep bump even with identical
+          #     source. References from HTML are normalized separately.
+          #   - Binary assets (images, fonts) at any path — never the regression
+          #     target of a dep bump.
+          # What remains: HTML pages, sitemap.xml, robots.txt, llms-full.txt,
+          # RSS/atom feeds — i.e. what we publish to users.
           set +e
           diff -r -u \
-            -x '*.js' -x '*.map' -x '*.css' \
+            -x 'assets' \
             -x '*.png' -x '*.jpg' -x '*.jpeg' -x '*.gif' -x '*.svg' -x '*.ico' -x '*.webp' \
             -x '*.woff' -x '*.woff2' -x '*.ttf' -x '*.otf' \
             -x '*.json' \
@@ -142,7 +146,7 @@ jobs:
           if [ $DIFF_EXIT -eq 0 ]; then
             echo "status=clean" >> "$GITHUB_OUTPUT"
             echo "files_changed=0" >> "$GITHUB_OUTPUT"
-            echo "✓ No HTML changes"
+            echo "✓ No content changes"
           elif [ $DIFF_EXIT -eq 1 ]; then
             MOD=$(grep -c "^diff " snapshot-diff.txt 2>/dev/null) || true
             ADDED=$(grep -c "^Only in build-pr" snapshot-diff.txt 2>/dev/null) || true
@@ -237,11 +241,11 @@ jobs:
               echo ""
               echo "See the [workflow run](${RUN_URL}) for the build log, then either: (a) close this PR, (b) bump a parent package alongside this one to restore compatibility, or (c) add a \`resolutions\` override."
             elif [ "$STATUS" = "clean" ]; then
-              echo "✅ **No HTML changes** — safe to merge."
+              echo "✅ **No content changes** — safe to merge."
             elif [ "$ACK" = "true" ]; then
               echo "✅ **${CHANGED} files changed — acknowledged via \`snapshot-acknowledged\` label**."
             else
-              echo "❌ **${CHANGED} HTML files changed** — review required before merge."
+              echo "❌ **${CHANGED} files changed** — review required before merge."
               echo ""
               echo "<details>"
               echo "<summary>First 200 lines of unified diff</summary>"
@@ -295,6 +299,6 @@ jobs:
           elif [ "${{ steps.build_head.outcome }}" = "failure" ]; then
             echo "::error::PR build broken — this dep bump is incompatible with the codebase"
           else
-            echo "::error::Snapshot gate failed — ${{ steps.diff.outputs.files_changed }} HTML files changed without 'snapshot-acknowledged' label"
+            echo "::error::Snapshot gate failed — ${{ steps.diff.outputs.files_changed }} files changed without 'snapshot-acknowledged' label"
           fi
           exit 1


### PR DESCRIPTION
## Summary

Two related cleanups exposed by [#306](https://github.com/iomete/iom-docs/pull/306) (webpack bump):

1. **Exclude `assets/` directory entirely** from the gate diff (`-x 'assets'`). Replaces the previous extension blacklist (`-x '*.js' -x '*.map' -x '*.css'`) which was missing `*.LICENSE.txt`.

2. **Drop the misleading "HTML" qualifier** from the sticky comment and error messages — the gate diffs more than just HTML (sitemap.xml, robots.txt, llms-full.txt, RSS/atom feeds).

## How this was surfaced

After Docusaurus 3.10.1 + NODE_OPTIONS landed, the gate on #306 finally completed both builds cleanly. It reported `❌ 8 HTML files changed`. The diff:

```
Only in build-pr/assets/js:    23923.a76d2b3b.js.LICENSE.txt
Only in build-base/assets/js:  23923.d06b40e8.js.LICENSE.txt
Only in build-base/assets/js:  90165.a381109d.js.LICENSE.txt
Only in build-pr/assets/js:    90165.c81a9f93.js.LICENSE.txt
...
```

All 8 were webpack-emitted `*.LICENSE.txt` sidecars. Webpack content-hashes the chunk filename including the LICENSE.txt sidecar — same chunk number `23923`, different hash → file is "different" by name. Not a content change. Pure rehash noise.

The previous extension list excluded `*.js`/`*.map`/`*.css` but didn't list `*.LICENSE.txt`. Easy to fix narrowly (`-x '*.LICENSE.txt'`), but better to think structurally: **all webpack output lives in `assets/`** — bundled chunks, sourcemaps, LICENSE files, anything else webpack decides to emit there. One directory-level exclusion is more durable than an ever-growing extension list.

## What's still diffed

The published artifacts users actually see:
- All `*.html` doc pages
- `sitemap.xml`
- `robots.txt`
- `llms-full.txt`
- Blog RSS/atom feeds

## What's now excluded as build-output noise

- Anything under `assets/` (webpack chunks + LICENSE.txt + maps)
- Static images at any path
- Fonts
- JSON state files

## Comment-language fix

Before:
> ❌ **8 HTML files changed** — review required before merge.

After (when content actually changes):
> ❌ **8 files changed** — review required before merge.

And when nothing changes:
> ✅ **No content changes** — safe to merge.

## Expected impact on #306

The webpack 5.95 → 5.105 bump should now produce **empty diff** after re-rebase. All the changed files were `assets/` rehash noise; user-facing HTML/sitemap/etc. were identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)