### PR TITLE
Add series navigation box to Iceberg maintenance posts 1 & 2

### DIFF
--- a/blog/2026-05-11-hidden-debt-in-lakehouse-tables.md
+++ b/blog/2026-05-11-hidden-debt-in-lakehouse-tables.md
@@ -18,6 +18,17 @@ import Img from '@site/src/components/Img';
 
 ---
 
+:::info Apache Iceberg Table Maintenance — a six-part series
+You're reading **Part 1**.
+
+1. **The Hidden Debt in Your Lakehouse Tables** — you are here
+2. [What Iceberg Gives You for Table Maintenance](/blog/iceberg-maintenance-operations)
+3. [The Iceberg Table Maintenance Landscape](/blog/iceberg-maintenance-alternatives)
+4. How We Built Automated Table Maintenance (coming soon)
+5. Running Iceberg Maintenance in Production (coming soon)
+6. Why We Rebuilt Orphan File Cleanup from Scratch (bonus, coming soon)
+:::
+
 Last year, a customer running a streaming CDC pipeline on our platform came to us with a problem. Their queries were taking 40% longer than they had three months ago. No schema changes. No new data sources. Same queries, same cluster size. Just... slower.
 
 The culprit wasn't a bad query plan or a misconfigured cluster. It was **45 million tiny data files** and roughly **5 TB of accumulated metadata**. The metadata had grown larger than the actual data. Their drivers were running out of memory just trying to figure out which files to read, before reading a single row.
@@ -247,7 +258,7 @@ Compaction, snapshot expiration, orphan cleanup, manifest rewriting. They work. 
 Most teams wire up cron jobs. Some rely on managed platforms. Plenty don’t think about it until queries start slowing down.
 
 To fix this properly, you need to understand how Iceberg handles maintenance. The four operations, how they work, and where the DIY approach starts to break down.
-We’ll go deeper into this in the next post.
+We’ll go deeper into this in the [next post](/blog/iceberg-maintenance-operations).
 
 ---
 ## Resources & further reading
@@ -257,6 +268,3 @@ We’ll go deeper into this in the next post.
 - [Iceberg Maintenance Procedures](https://iceberg.apache.org/docs/latest/maintenance/): official guide to compaction, snapshot expiration, orphan cleanup, and manifest rewriting
 - [Iceberg Table Inspection Queries](https://iceberg.apache.org/docs/latest/spark-queries/#inspecting-tables): how to query metadata tables (data_files, snapshots, manifests) for table health diagnostics
 - [Apache Parquet Format](https://parquet.apache.org/docs/): columnar storage format used by Iceberg data files
-
-#### Series
-- [Part 2: Apache Iceberg Table Maintenance: What Iceberg Ships and What It Doesn't](/blog/iceberg-maintenance-operations)

--- a/blog/2026-05-25-iceberg-maintenance-operations.md
+++ b/blog/2026-05-25-iceberg-maintenance-operations.md
@@ -19,6 +19,17 @@ import Img from '@site/src/components/Img';
 
 ---
 
+:::info Apache Iceberg Table Maintenance — a six-part series
+You're reading **Part 2**.
+
+1. [The Hidden Debt in Your Lakehouse Tables](/blog/hidden-debt-in-lakehouse-tables)
+2. **What Iceberg Gives You for Table Maintenance** — you are here
+3. [The Iceberg Table Maintenance Landscape](/blog/iceberg-maintenance-alternatives)
+4. How We Built Automated Table Maintenance (coming soon)
+5. Running Iceberg Maintenance in Production (coming soon)
+6. Why We Rebuilt Orphan File Cleanup from Scratch (bonus, coming soon)
+:::
+
 Every team running [Apache Iceberg](https://iceberg.apache.org/) in production eventually hits the same wall. Queries get slower, storage costs go up, and someone opens a ticket. The engineer who looks into it finds that Iceberg includes the maintenance primitives, but not the automation or guidance for when to use them.
 
 This is the second post in our series on Iceberg table maintenance. [Part 1](/blog/hidden-debt-in-lakehouse-tables) covered the hidden cost of ignoring it. This post explains what Iceberg gives you out of the box, what each operation does at the file level, and where the DIY approach starts to fail. We worked through most of these options before building our own system, and the gaps cost us real time.
@@ -492,7 +503,3 @@ For smaller deployments with a handful of tables, cron jobs and scripts are usua
 #### Community & DIY
 - [IOMETE Data Compaction Job](/resources/open-source-spark-jobs/data-compaction-job): open-source Spark job for scheduled Iceberg compaction
 - [Automating Apache Iceberg Maintenance with Spark and Python](https://medium.com/@vincent_daniel/automating-apache-iceberg-maintenance-with-spark-and-python-ee1a253de86c): Python class approach with size-based table classification
-
-#### Series
-- [Part 1: The Hidden Debt in Your Lakehouse Tables](/blog/hidden-debt-in-lakehouse-tables)
-- Part 3: The Iceberg Table Maintenance Landscape (coming soon)


### PR DESCRIPTION
### Summary
Adds a series-navigation admonition to the top of Parts 1 and 2 of the Iceberg table maintenance blog series. Removes the old bottom-of-page series link lists, which are now superseded.

### Context
Parts 1 and 2 are live. With Part 3 also now published, readers landing on either post had no way to discover the full series without scrolling to the bottom. The footer link lists were also incomplete and inconsistent between posts.

### Implementation
- Added a `:::info` admonition at the top of each post listing all 6 parts; current part marked "you are here", published parts (1–3) linked, unpublished parts (4–6) marked "(coming soon)"
- Removed the `#### Series` footer sections from both posts
- In Part 1, upgraded the inline "next post" prose reference to a hyperlink to Part 2
