### PR TITLE
Docs/cleanup untracked folders job

### DIFF
--- a/docs/deployment/on-prem/release-notes/marketplace-jobs.md
+++ b/docs/deployment/on-prem/release-notes/marketplace-jobs.md
@@ -25,6 +25,21 @@ import { Release, NewFeatures, Improvements, BugFixes, ReleaseDescription, Depre
 
 ## Recent Releases
 
+<Release name="Cleanup Untracked Table Folders Job" version="0.1.0" date="June 9, 2026">
+  <NewFeatures>
+    Added a new marketplace job for safely identifying and cleaning up untracked table folders in object storage.
+
+    This first release introduces an on-demand cleanup workflow that compares catalog active table locations with physical storage folders before taking any destructive action.
+
+    - ✅ Dry-run mode to review cleanup candidates before deletion
+    - ✅ Active table protection based on catalog metadata
+    - ✅ Exclusion rules for protected paths and database folders
+    - ✅ Age filtering and candidate limits for safer cleanup
+    - ✅ Controlled deletion with audit logging for each run
+  </NewFeatures>
+</Release>
+
+
 <Release name="Catalog Sync Job" version="5.0.1" date="April 29, 2026">
     <Improvements>
       This release focuses on improving catalog sync performance by reducing heavy Spark metadata queries and introducing parallelism for schema processing and indexing.

--- a/docs/open-source-spark-jobs/cleanup-untracked-table-folders-job.mdx
+++ b/docs/open-source-spark-jobs/cleanup-untracked-table-folders-job.mdx
@@ -16,7 +16,7 @@ The **Cleanup Untracked Table Folders Job** helps find table folders that still 
 Use this job when tables were dropped without purging their physical files. It can run in dry-run mode to report candidate folders, and it deletes folders only when deletion is explicitly enabled.
 
 - **Version**: `0.1.0`
-- **Source**: [View on GitHub](https://github.com/iomete/iomete-marketplace-jobs/tree/main/cleanup-untracked-table-folders)
+- **Source**: [View on GitHub](https://github.com/iomete/iomete-marketplace-jobs/tree/main/cleanup-untracked-table-folders-job)
 
 :::warning
 This job can delete data from object storage. Always run it in dry-run mode first, review the candidates and audit table, and only enable deletion after confirming the output.

--- a/docs/open-source-spark-jobs/cleanup-untracked-table-folders-job.mdx
+++ b/docs/open-source-spark-jobs/cleanup-untracked-table-folders-job.mdx
@@ -1,9 +1,9 @@
 ---
 title: Cleanup Untracked Table Folders Job
-sidebar_label: Cleanup Untracked Table Folders
+sidebar_label: Cleanup Untracked Folders
 description: Identify and optionally delete table folders that remain in object storage but are no longer tracked by the catalog.
 last_update:
-  date: 05/23/2026
+  date: 06/09/2026
   author: Hasan
 ---
 
@@ -258,6 +258,19 @@ Common `status_reason` values include:
 | `database_location_missing` | Database exists but has no usable storage location. |
 | `no_active_tables_in_database` | Database has no active table locations, so cleanup is skipped by default. |
 | `too_many_candidate_folders` | Candidate count exceeded `max_candidate_folders_per_database`. |
+
+## Understanding Summary Logs
+
+The job prints several folder lists in the driver logs. Two of them are commonly confused:
+
+| Log section | Source | Meaning |
+|---|---|---|
+| `Protected catalog active table locations` | Catalog metadata | Active table locations discovered from the catalog. These paths are used as the protection set and must not be deleted. This list may include paths outside the selected storage scan root. |
+| `Storage folders not selected as candidates` | Object-storage scan | Physical folders found under the scan root but skipped because they matched a protection rule, such as active table location, excluded path, excluded database folder, or age filter. |
+| `Untracked candidate folders selected for cleanup` | Candidate detection | Scanned folders that were not protected and passed cleanup filters. These are the folders the job would delete in deletion mode. |
+| `Deleted folders` | Deletion result | Candidate folders actually deleted when `dry_run=false` and `delete_enabled=true`. |
+
+In short, catalog active table locations come from catalog metadata, while storage folders come from the physical object-storage scan.
 
 ## Summary
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -230,6 +230,7 @@ const sidebars = {
         "open-source-spark-jobs/data-compaction-job",
         "open-source-spark-jobs/query-scheduler-job",
         "open-source-spark-jobs/catalog-sync-job",
+        "open-source-spark-jobs/cleanup-untracked-table-folders-job",
         "open-source-spark-jobs/mysql-database-replication-job",
         "open-source-spark-jobs/kafka-streaming",
         "open-source-spark-jobs/file-streaming",


### PR DESCRIPTION
Adds documentation updates for the cleanup untracked table folders marketplace job.

Changes:
- Adds the cleanup job to the Open Source Spark Jobs sidebar
- Adds the job to the Marketplace Jobs release notes and latest versions table
- Adds summary log interpretation notes for catalog-active locations vs scanned storage folders