### PR TITLE
docs: align kafka and mysql marketplace job slugs with job names

### DIFF
--- a/docs/deployment/on-prem/release-notes/marketplace-jobs.md
+++ b/docs/deployment/on-prem/release-notes/marketplace-jobs.md
@@ -16,8 +16,8 @@ import { Release, NewFeatures, Improvements, BugFixes, ReleaseDescription, Depre
 | Data Compaction          | iomete_data_compaction  | 1.2.13   | [Open ↗](/resources/open-source-spark-jobs/data-compaction)            |
 | File Streaming           | iomete-file-streaming   | 1.0.1    | [Open ↗](/resources/open-source-spark-jobs/file-streaming-job)             |
 | Catalog Sync             | iom-catalog-sync        | 5.0.1    | [Open ↗](/resources/open-source-spark-jobs/catalog-sync)               |
-| MySQL Sync               | iomete_mysql_sync       | 3.0.0    | [Open ↗](/resources/open-source-spark-jobs/mysql-database-replication-job) |
-| Kafka Iceberg Stream     | kafka-iceberg-stream    | 1.2.0    | [Open ↗](/resources/open-source-spark-jobs/kafka-streaming-job)            |
+| MySQL Sync               | iomete_mysql_sync       | 3.0.0    | [Open ↗](/resources/open-source-spark-jobs/mysql-db-sync)                  |
+| Kafka Iceberg Stream     | kafka-iceberg-stream    | 1.2.0    | [Open ↗](/resources/open-source-spark-jobs/kafka-iceberg-stream)           |
 | Query Scheduler          | spark-py                | 3.5.7-v1 | [Open ↗](/resources/open-source-spark-jobs/query-scheduler-job)            |
 | TPC-DS Iceberg Generator | tpcds-iceberg-generator | 3.5.5    | Use job-templates in IOMETE                                                |
 | Cleanup Untracked Table Folders | cleanup-untracked-table-folders | 0.1.0 | [Open ↗](/resources/open-source-spark-jobs/cleanup-untracked-table-folders) |

--- a/docs/open-source-spark-jobs/getting-started.mdx
+++ b/docs/open-source-spark-jobs/getting-started.mdx
@@ -39,7 +39,7 @@ For the latest version of each job, see the [Marketplace Jobs release notes](../
 
 <Card
   title="MySQL Database Replication Job"
-  link="open-source-spark-jobs/mysql-database-replication-job"
+  link="open-source-spark-jobs/mysql-db-sync"
 >
   Move MySQL tables into the IOMETE Lakehouse with a simple, configuration-driven Spark job.
 </Card>
@@ -68,7 +68,7 @@ For the latest version of each job, see the [Marketplace Jobs release notes](../
 
 <Card
   title="Kafka to IOMETE Lakehouse Data Replication Job"
-  link="open-source-spark-jobs/kafka-streaming-job"
+  link="open-source-spark-jobs/kafka-iceberg-stream"
 >
   A ready-to-use Spark Streaming job that replicates Kafka topics into the IOMETE Lakehouse through configuration alone.
 </Card>

--- a/docs/open-source-spark-jobs/kafka-streaming.md
+++ b/docs/open-source-spark-jobs/kafka-streaming.md
@@ -1,7 +1,7 @@
 ---
 title: Kafka Streaming
 description: Learn how to move data from Kafka to Iceberg using IOMETE. This guide covers deserialization, job creation, configuration, and testing.
-slug: kafka-streaming-job
+slug: kafka-iceberg-stream
 last_update:
   date: 08/24/2023
   author: Vugar Dadalov

--- a/docs/open-source-spark-jobs/mysql-database-replication-job.md
+++ b/docs/open-source-spark-jobs/mysql-database-replication-job.md
@@ -2,6 +2,7 @@
 title: MySQL Database Replication Job
 sidebar_label: MySQL Database Replication
 description: Replicate MySQL tables to the IOMETE Lakehouse with a configuration-driven Spark job. Supports full load and incremental snapshot sync modes.
+slug: mysql-db-sync
 last_update:
   date: 05/07/2026
   author: Rocco Verhoef


### PR DESCRIPTION
Aligns documentation page slugs with the marketplace job names so the doc links match the job identities exactly.

## Changes
- `kafka-streaming-job` slug → **`kafka-iceberg-stream`**
- `mysql-database-replication-job` slug → **`mysql-db-sync`**

Updated in:
- `docs/open-source-spark-jobs/kafka-streaming.md` and `mysql-database-replication-job.md` (frontmatter `slug`)
- `docs/open-source-spark-jobs/getting-started.mdx` (marketplace cards)
- `docs/deployment/on-prem/release-notes/marketplace-jobs.md` (Latest Versions table)

The other five jobs (catalog-sync, data-compaction, query-scheduler-job, file-streaming-job, cleanup-untracked-table-folders) already matched their job names. The sidebar references file IDs rather than slugs, so no sidebar change was needed.

## Note
`tpcds-generator` has no dedicated doc page yet, so its slug can't be aligned in this PR.