### PR TITLE
Show "Last updated" date in blog post footer (GRO-857)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "iom-docs",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "start"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/src/theme/BlogPostItem/Footer/index.js
+++ b/src/theme/BlogPostItem/Footer/index.js
@@ -1,0 +1,46 @@
+import React from "react";
+import clsx from "clsx";
+import Footer from "@theme-original/BlogPostItem/Footer";
+import EditMetaRow from "@theme/EditMetaRow";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import { useBlogPost } from "@docusaurus/plugin-content-blog/client";
+
+// IOMETE blog posts use a custom `tags2` frontmatter field (not the standard
+// `tags`) and the blog has no `editUrl`. The default BlogPostItem/Footer
+// early-returns `null` when there are no standard tags / editUrl, which also
+// hides the "Last updated" line even though `showLastUpdateTime` is enabled
+// and `lastUpdatedAt` is computed. This wrapper renders the original footer,
+// then appends the Last-updated row (above the pagination) whenever the
+// original footer would have skipped it.
+export default function FooterWrapper(props) {
+  const { metadata, isBlogPostPage } = useBlogPost();
+  const { tags, editUrl, hasTruncateMarker, lastUpdatedAt, lastUpdatedBy } =
+    metadata;
+
+  const tagsExists = tags.length > 0;
+  const truncatedPost = !isBlogPostPage && hasTruncateMarker;
+  // Mirrors the default footer's render guard so we only step in when it bails.
+  const originalRendersFooter = tagsExists || truncatedPost || !!editUrl;
+
+  const showLastUpdated =
+    isBlogPostPage && !originalRendersFooter && (lastUpdatedAt || lastUpdatedBy);
+
+  return (
+    <>
+      <Footer {...props} />
+      {showLastUpdated && (
+        <footer className="docusaurus-mt-lg">
+          <EditMetaRow
+            className={clsx(
+              "margin-top--sm",
+              ThemeClassNames.blog.blogFooterEditMetaRow
+            )}
+            editUrl={editUrl}
+            lastUpdatedAt={lastUpdatedAt}
+            lastUpdatedBy={lastUpdatedBy}
+          />
+        </footer>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- IOMETE blog posts use a custom `tags2` frontmatter field (not the standard `tags`) and the blog has no `editUrl`, so the default Docusaurus `BlogPostItem/Footer` early-returns `null` and never renders the "Last updated" line — even though `showLastUpdateTime: true` is set and `lastUpdatedAt` is computed from the `last_update` frontmatter.
- Add a `BlogPostItem/Footer` swizzle that appends the standard last-updated row at the bottom of the post (above the pagination), reusing the theme's own `EditMetaRow`/`LastUpdated` components so styling and dark mode match the rest of the site.
- Remove a misplaced `Header/Info` swizzle (added earlier, never committed) that incorrectly showed "Last updated" at the *top* of the post.
- Enable `autoPort` in `.claude/launch.json` so the local preview server can start when port 3000 is busy.

## Test plan

- [ ] Open any blog post — "Last updated on <date>" appears at the bottom, above the Newer/Older pagination
- [ ] The post header shows only the publish date + reading time (no "Last updated")
- [ ] `npm run build` succeeds

Linear: https://linear.app/iomete/issue/GRO-857/show-last-updated-date-in-blog-post-footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
