### PR TITLE
build(deps): patch ws and uuid for Dependabot alerts #257, #244

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sharp": "^0.34.5",
     "tailwindcss": "^3.4.19"
   },
-  "//resolutions": "Pinned to patch vulnerable transitive deps that parent packages still pull at insecure versions. See PRs #380 (picomatch) and #383 (the other 7) for the original Dependabot alerts each entry addresses. Don't remove an entry without confirming the parent no longer needs the vulnerable version — check with `yarn why <pkg>`.",
+  "//resolutions": "Pinned to patch vulnerable transitive deps that parent packages still pull at insecure versions. See PRs #380 (picomatch) and #383 (the other 7) for the original Dependabot alerts each entry addresses. ws (#257, webpack-bundle-analyzer) and uuid (#244, sockjs) were added later for the same reason. Note: Dependabot alert #260 (js-yaml DoS via merge keys) cannot be auto-fixed — gray-matter@4.0.3 pins js-yaml@^3 and calls safeLoad/safeDump, which js-yaml 4.2.0 (the only patched release) removed, so forcing it breaks the build; the exposure is build-time only, parsing trusted in-repo frontmatter. Don't remove an entry without confirming the parent no longer needs the vulnerable version — check with `yarn why <pkg>`.",
   "resolutions": {
     "**/@parcel/watcher/picomatch": "^4.0.4",
     "**/picomatch": "^2.3.2",
@@ -53,7 +53,9 @@
     "**/cross-spawn": "^7.0.5",
     "**/glob/minimatch": "^9.0.7",
     "**/serve-handler/minimatch": "^3.1.4",
-    "**/qs": "^6.15.2"
+    "**/qs": "^6.15.2",
+    "**/webpack-bundle-analyzer/ws": "^7.5.11",
+    "**/sockjs/uuid": "^11.1.1"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,7 +3895,7 @@ arg@^5.0.0, arg@^5.0.2:
 
 argparse@^1.0.7:
   version "1.0.10"
-  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
@@ -5540,7 +5540,7 @@ eslint-scope@5.1.1:
 
 esprima@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esrecurse@^4.3.0:
@@ -9872,7 +9872,7 @@ spdy@^4.0.2:
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 srcset@^4.0.0:
@@ -10455,10 +10455,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^11.1.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 validate-peer-dependencies@^2.2.0:
   version "2.2.0"
@@ -10709,10 +10709,10 @@ write-file-atomic@^3.0.3:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.3.1:
-  version "7.5.10"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+ws@^7.3.1, ws@^7.5.11:
+  version "7.5.11"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.11.tgz#9460daf1812bb81a423c5b9eac746941a86310fa"
+  integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
 
 ws@^8.18.0:
   version "8.21.0"


### PR DESCRIPTION
Fixes 2 of the 3 open Dependabot alerts by pinning patched versions of vulnerable transitive dependencies via `yarn` `resolutions`.

## Fixed

| Alert | Pkg | Sev | Change | Pulled in via |
|---|---|---|---|---|
| #257 | ws | high | 7.5.10 → **7.5.11** | webpack-bundle-analyzer |
| #244 | uuid | medium | 8.3.2 → **11.1.1** | webpack-dev-server → sockjs |

- `ws`: in-major patch for the memory-exhaustion DoS.
- `uuid`: major bump (8 → 11). `sockjs` only uses `uuid.v4()`, so it's compatible.
- Full `yarn build` verified to succeed with both changes.

## Not fixed here — alert #260 (js-yaml, medium)

`js-yaml@3.14.2` (DoS via merge keys) comes from `gray-matter@4.0.3`, which pins `js-yaml@^3` and calls `safeLoad`/`safeDump`. The only patched release is `js-yaml@4.2.0`, which **removed** those functions — forcing it breaks the build (`Function yaml.safeLoad is removed in js-yaml 4`). There is no patched 3.x release.

Exposure is **build-time only** (gray-matter parses trusted in-repo frontmatter, not untrusted input). Recommend dismissing #260 as "risk tolerable" until Docusaurus/gray-matter ships a js-yaml 4 compatible version. Rationale documented in the `//resolutions` comment in `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)