### PR TITLE
fix(analytics): remove duplicate GA4 gtag, let GTM own G-YMX75JE2MY

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,10 +101,11 @@ const config = {
         googleTagManager: {
           containerId: "GTM-W4ZH33W",
         },
-        gtag: {
-          trackingID: "G-YMX75JE2MY",
-          anonymizeIP: false,
-        },
+        // GA4 (G-YMX75JE2MY) is fired by the GTM container above via its
+        // container-wide "Initialization - All Pages" tag. The standalone
+        // @docusaurus/plugin-google-gtag was removed to stop G-YMX75JE2MY
+        // being bootstrapped twice per page (duplicate gtag/js load +
+        // double-counted events). GTM is now the sole GA4 mechanism.
         sitemap: {
           changefreq: "weekly",
           priority: 0.5,

--- a/src/gtagFallback.js
+++ b/src/gtagFallback.js
@@ -1,8 +1,8 @@
 // Ensures `window.gtag` is always callable.
 //
-// The @docusaurus/plugin-google-gtag route-change handler calls `window.gtag()`
-// on every navigation. If a privacy/ad blocker strips the plugin's inline init
-// script, `window.gtag` is undefined and each page switch throws
+// GA4 is fired through the GTM container (see docusaurus.config.js), which
+// defines the real `window.gtag` at runtime. Until that loads — or if a
+// privacy/ad blocker strips it — any stray `window.gtag()` call would throw
 // "window.gtag is not a function". Defining a no-op fallback here (this module
 // runs during app bootstrap, before any route update) prevents the error while
 // leaving the real gtag untouched when it does load.


### PR DESCRIPTION
The docs site initialized GA4 property G-YMX75JE2MY twice per page: once via @docusaurus/plugin-google-gtag (standalone gtag/js load) and again via the GTM container GTM-W4ZH33W, which fires the same property container-wide on its Initialization - All Pages tag. This produced a duplicate gtag/js script load and double-counted pageviews/events.

Remove the standalone gtag preset option so GTM is the sole GA4 mechanism. Update gtagFallback.js's comment to reflect that GTM now defines the real window.gtag.

Relates to ENG-1823.