### PR TITLE
docs(arrow-jdbc): document driver release -iomete.3 (catalog scoping) and modern-JDK flags

### DIFF
--- a/docs/integrations/dbtools/dbeaver.md
+++ b/docs/integrations/dbtools/dbeaver.md
@@ -3,7 +3,7 @@ title: DBeaver
 description: Connect DBeaver to IOMETE using the Arrow Flight SQL JDBC driver.
 sidebar_label: DBeaver
 last_update:
-  date: 2026-06-12
+  date: 2026-07-22
   author: Mateus Aubin
 ---
 
@@ -72,6 +72,39 @@ With the driver registered, you can open a connection and browse your data.
 If the connection succeeds, the **Database Navigator** lists your catalogs, schemas, and tables so you can start querying.
 
 <Img src="/img/database-drivers/dbeaver/explorer.png" alt="Database Navigator showing IOMETE catalogs and tables" />
+
+## Java Version Requirements
+
+If Arrow Flight connections fail the moment you hit **Test Connection**, a modern version of Java is usually the cause. DBeaver bundles and runs its own copy of Java, independent of any Java installed on your machine. On **Java 16 and newer**, the Arrow Flight SQL driver needs a couple of extra startup flags. Without them, it can't set up its memory and the connection fails right away, usually with a `Could not initialize class ...RootAllocator` error. See [Symptoms Without the Flags](/user-guide/driver/arrow-flight-jdbc-driver#symptoms-without-the-flags) in the driver guide for the full error messages.
+
+:::warning Auto-Update Can Trigger This Overnight
+A DBeaver update can silently swap its bundled Java for a newer version. A setup that worked yesterday then starts failing, even though you never touched your driver or connection. So if Arrow Flight breaks right after a DBeaver update, apply the flags below.
+:::
+
+Add the required flags to `dbeaver.ini`:
+
+1. Locate `dbeaver.ini`:
+   - **macOS**: `DBeaver.app/Contents/Eclipse/dbeaver.ini` (right-click the app → **Show Package Contents**)
+   - **Windows**: `dbeaver.ini` next to `dbeaver.exe` in the install folder
+   - **Linux**: `dbeaver.ini` in the install directory
+
+2. Add each flag on its own line **after** the `-vmargs` line (every argument in `dbeaver.ini` must be on a separate line):
+
+   ```ini
+   -vmargs
+   --add-opens=java.base/java.nio=ALL-UNNAMED
+   --sun-misc-unsafe-memory-access=allow
+   ```
+
+   Each flag does the following:
+   - `--add-opens=java.base/java.nio=ALL-UNNAMED` opens Java's internal `java.nio` package so the driver can reach the direct memory it needs. Java's module system blocks this by default on **Java 16 and newer** ([JEP 396](https://openjdk.org/jeps/396)).
+   - `--sun-misc-unsafe-memory-access=allow` re-enables the internal `Unsafe` memory API the driver relies on. **Java 24** only prints a deprecation warning, but **Java 25 and newer** deny it by default, so without this flag the driver can't initialize its memory allocator ([JEP 498](https://openjdk.org/jeps/498)).
+
+   Include `--sun-misc-unsafe-memory-access=allow` only if DBeaver's bundled Java is **version 24 or newer**; on older versions it prevents startup. When unsure, add `--add-opens` first, retry, and add the second flag only if the failure persists.
+
+3. **Fully quit and restart** DBeaver (a window reload isn't enough), then retry **Test Connection**.
+
+For the per-version flag matrix and the reasoning behind each flag, see [Java Version Requirements](/user-guide/driver/arrow-flight-jdbc-driver#java-version-requirements) in the driver guide.
 
 ## Resources
 

--- a/user-guide/driver/arrow-flight-jdbc-driver.mdx
+++ b/user-guide/driver/arrow-flight-jdbc-driver.mdx
@@ -1,9 +1,9 @@
 ---
 title: Arrow Flight SQL JDBC Driver
 sidebar_label: Arrow Flight SQL JDBC Driver
-description: IOMETE's Arrow Flight SQL JDBC driver, a fork of the standard driver adding HTTP CONNECT proxy support, query timeout, and named parameters.
+description: IOMETE's Arrow Flight SQL JDBC driver, a fork of the standard driver adding proxy support, query timeout, named parameters, and BI catalog scoping.
 last_update:
-  date: 2026-06-12
+  date: 2026-07-22
   author: Mateus Aubin
 ---
 
@@ -11,22 +11,24 @@ import Card from "@site/src/components/Card";
 import GridBox from "@site/src/components/GridBox";
 
 IOMETE provides a custom release of the [Apache Arrow Flight SQL JDBC driver](https://arrow.apache.org/java/main/flight_sql_jdbc_driver.html). 
-It's functionally identical to the upstream driver, with three additions:
+It's functionally identical to the upstream driver, with a few IOMETE-specific additions:
 
 - **HTTP CONNECT proxy tunneling**: routes gRPC/Flight connections through an enterprise HTTP proxy&nbsp;[›](#http-proxy-configuration)
 - **Connection-level query timeout**: sets a per-connection default timeout applied to every statement&nbsp;[›](#query-timeout)
 - **Named parameters**: allows `:name` syntax as an alternative to positional `?` markers&nbsp;[›](#named-parameters)
+- **Catalog scoping for BI tools**: pins a connection to one catalog for clients that aren't catalog-aware (such as Oracle)&nbsp;[›](#catalog-scoping-for-bi-tools)
 
-It also supports standard mutual TLS, presenting a client certificate when your endpoint requires one. See [Client Certificates (mTLS)](#client-certificates-mtls).
+It also supports standard mutual TLS and can present a client certificate when your endpoint requires one. See [Client Certificates (mTLS)](#client-certificates-mtls).
 
 ## Download the Driver
 
+IOMETE maintains its own build of the Arrow Flight SQL driver. 
 Download the latest release from the [iomete-artifacts](https://github.com/iomete/iomete-artifacts) GitHub repository.
 
 Driver artifacts follow the naming convention `flight-sql-jdbc-driver-<upstream>-iomete.<release>.jar`, 
 where `<upstream>` is the Arrow Flight SQL version 
 and `<release>` is the IOMETE release number 
-(e.g. `flight-sql-jdbc-driver-19.0.0-iomete.2.jar`).
+(e.g. `flight-sql-jdbc-driver-19.0.0-iomete.3.jar`).
 
 ## Query Timeout
 
@@ -59,10 +61,46 @@ ResultSet rs = ps.executeQuery();
 The same name can appear multiple times in a query, and the driver binds the value to every occurrence.
 Positional `?` and named `:name` markers cannot be mixed in the same statement.
 
+## Catalog Scoping for BI Tools
+
+*Requires driver **≥ 19.0.0-iomete.3**.*
+
+Some JDBC clients aren't catalog-aware. Business Intelligence (BI) tools such as **Oracle Analytics Server and BI Publisher** assume a two-part `schema.table` name hierarchy and drop the catalog prefix entirely. Since IOMETE organizes data in three parts (`catalog.schema.table`), these clients mix schemas and tables from every catalog together in their object lists, and their queries fail because two-part names don't say which catalog to use.
+
+Catalog scoping fixes this by pinning the connection to a single catalog: the client keeps using two-part names, and the driver supplies the catalog they leave out. To enable it, set `compatibilityMode=oracle` (or `catalogFilterEnabled=true`) and name the catalog in the `schema` parameter.
+
+| Parameter | Values | Default | Effect |
+| --- | --- | --- | --- |
+| `compatibilityMode` | `oracle` | unset | Turns on catalog filtering for Oracle-style tools. Other values have no effect. |
+| `catalogFilterEnabled` | `true` / `false` | `false` | Turns catalog filtering on or off directly. An explicit value always overrides `compatibilityMode`. |
+| `schema` | `catalog[.namespace]` | unset | The first (catalog) part becomes the metadata filter. Anything after the first dot is an execution hint only, not a metadata filter. |
+
+When scoping is on, the driver limits metadata calls (`getCatalogs`, `getSchemas`, `getTables`, `getColumns`, and the key-metadata calls) to the catalog you name. Scoping works at the catalog level: within the pinned catalog, all schemas and tables stay visible. To reach more than one catalog from a client that isn't catalog-aware, define one connection per catalog.
+
+### Scoping Examples
+
+Append the catalog parameters to your base JDBC URL (`jdbc:arrow-flight-sql://<host>:<port>?user=<username>&password=<token>`):
+
+```ini
+# Pin an Oracle BI connection to a single catalog
+...&compatibilityMode=oracle&schema=spark_catalog
+
+# Scope metadata to a catalog, with a namespace hint within it
+...&compatibilityMode=oracle&schema=spark_catalog.sales
+
+# Turn on scoping for a non-Oracle tool that isn't catalog-aware
+...&catalogFilterEnabled=true&schema=spark_catalog
+```
+
+:::note
+- Existing connections are unaffected: without `compatibilityMode` or `catalogFilterEnabled`, `schema` behaves exactly as before.
+- If `schema` is malformed, the driver ignores the filter and logs a warning instead of failing the connection.
+:::
+
 ## HTTP Proxy Configuration
 
-Proxy settings are passed as query parameters appended to the JDBC URL. 
-No code changes are needed in your application.
+You configure the proxy through query parameters on the JDBC URL, 
+so your application code doesn't change.
 
 The proxy must support **HTTP CONNECT tunneling** (standard for HTTPS/gRPC traffic). 
 SOCKS proxies are not supported. 
@@ -116,11 +154,11 @@ java -Dhttps.proxyHost=proxy.corp.internal -Dhttps.proxyPort=3128 -jar your-app.
 ```
 
 You can also set `proxyHost`/`proxyPort` directly in the JDBC URL to use a connection-specific proxy, independently of the JVM-level proxy. 
-This means it is possible to route general Java traffic through one proxy and IOMETE JDBC connections through another.
+So you can route general Java traffic through one proxy and IOMETE JDBC connections through another.
 
 To suppress JVM proxy resolution for a specific connection without changing JVM properties, add `proxyDisable=force` to the JDBC URL.
 
-### Examples
+### Proxy Examples
 
 All examples use the base JDBC URL format:
 
@@ -167,6 +205,81 @@ If your IOMETE endpoint requires mutual TLS, the driver can present a client cer
 ```
 jdbc:arrow-flight-sql://<host>:<port>?user=<username>&password=<token>&useEncryption=true&clientCertificate=/path/to/client-cert.pem&clientKey=/path/to/client-key.pem
 ```
+
+## Java Version Requirements
+
+For performance reasons, the Apache Arrow JDBC driver manages its own memory directly instead of leaving it to Java's garbage collector. It does this through low-level Java internals that recent Java versions lock down by default. As a result, on **Java 16 and newer** you must add one or two extra startup flags to whichever program loads the driver, whether that's DBeaver, Oracle BI, your own Java application, or another JDBC client. Without them, the driver fails while setting up its memory, usually at connect time or on the first query. The exact flags depend on your Java version (see the matrix below).
+
+This is a known requirement of every Arrow-based driver (upstream and the IOMETE build alike), not an IOMETE-specific bug. Apache Arrow documents it in its [Installing Java Modules](https://arrow.apache.org/docs/19.0/java/install.html) guide. It can't be fixed inside the driver: a driver can't change the Java startup options of the program that loads it.
+
+### Flag Matrix
+
+Find your Java version below to see which flags to add.
+
+| Java version | Flags to add | Why |
+| --- | --- | --- |
+| <span style={{whiteSpace: 'nowrap'}}>8–15</span> | None | No limits on direct-memory access |
+| <span style={{whiteSpace: 'nowrap'}}>16–23</span> | `--add-opens=java.base/java.nio=ALL-UNNAMED` | Java's module system now blocks the driver's direct-memory access ([JEP 396](https://openjdk.org/jeps/396)) |
+| <span style={{whiteSpace: 'nowrap'}}>24</span> | `--add-opens=java.base/java.nio=ALL-UNNAMED`<br/>`--sun-misc-unsafe-memory-access=allow` _(recommended)_ | The driver still works on Java 24 with only `--add-opens`, but its use of the internal `Unsafe` memory API now prints a deprecation warning; `allow` silences it ([JEP 498](https://openjdk.org/jeps/498)) |
+| <span style={{whiteSpace: 'nowrap'}}>25+</span> | `--add-opens=java.base/java.nio=ALL-UNNAMED`<br/>`--sun-misc-unsafe-memory-access=allow` | Java now denies the internal `Unsafe` memory API by default; without `allow` the driver can't initialize its memory allocator and fails at connect time ([JEP 498](https://openjdk.org/jeps/498)) |
+
+:::warning
+`--sun-misc-unsafe-memory-access=allow` exists only on **Java 24 and newer**. Adding it on an older version stops Java from starting, so add it only when you actually run Java 24 or later.
+
+Use exactly `=allow`. The other accepted values (`=warn`, `=deny`) both make the driver fail to initialize its allocator, even on Java 24 where the default (flag omitted) otherwise works.
+:::
+
+### Symptoms Without the Flags
+
+If the flags are missing, the connection fails while the driver sets up its memory. The exact error depends on your Java version.
+
+On **Java 16–23**, you get a reflective-access error, one of:
+
+```text
+InaccessibleObjectException: module java.base does not "opens java.nio" to unnamed module
+UnsupportedOperationException: sun.misc.Unsafe or java.nio.DirectByteBuffer.<init>(long, int) not available
+```
+
+On **Java 24**, the driver still connects with only `--add-opens`, but prints a deprecation warning on first use:
+
+```text
+WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
+WARNING: sun.misc.Unsafe::allocateMemory has been called by ...io.netty.util.internal.PlatformDependent0
+```
+
+Add `--sun-misc-unsafe-memory-access=allow` to silence it.
+
+On **Java 25 and newer**, the same `Unsafe` access is denied by default, so the driver fails outright while initializing its allocator (from the bundled Netty library):
+
+```text
+ExceptionInInitializerError: Could not initialize class ...RootAllocator
+Caused by: UnsupportedOperationException ... EmptyByteBuf.memoryAddress()
+```
+
+### Passing the Flags
+
+Add the flags to the **program that loads the driver**. For an application you launch yourself:
+
+```bash
+java --add-opens=java.base/java.nio=ALL-UNNAMED \
+     --sun-misc-unsafe-memory-access=allow \
+     -jar your-app.jar
+```
+
+If you can't edit the launch command (for example, a tool that starts its own Java runtime), set the `JDK_JAVA_OPTIONS` environment variable instead. Java reads it automatically:
+
+```bash
+export JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow"
+```
+
+For GUI database tools and application servers, the flags go in that product's own Java settings, not in your application:
+
+- **DBeaver**: add them to `dbeaver.ini`. See [Java Version Requirements](/integrations/dbtools/dbeaver#java-version-requirements) in the DBeaver guide.
+- **Oracle BI / BI Publisher (WebLogic)**: add them to the domain's Java options, for example `setDomainEnv.sh` via `EXTRA_JAVA_PROPERTIES`, or the `JDK_JAVA_OPTIONS` environment variable, then restart the server.
+
+:::note
+Apache Arrow documents the longer form `--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`. Because the driver ships Arrow shaded on the classpath (the unnamed module), the `ALL-UNNAMED` target is the part that matters; the shorter form above is sufficient. See Arrow's [Installing Java Modules](https://arrow.apache.org/docs/19.0/java/install.html) guide.
+:::
 
 ## Resources
 


### PR DESCRIPTION


## Summary

Documents two field-driven requirements for the IOMETE Arrow Flight SQL JDBC driver and adds a new BI-compatibility feature:

1. **Java version requirements (JDK 16+)** — the JVM startup flags the driver needs on modern JDKs, with a per-version matrix, the exact errors seen without them, and where to set them. Driven by field hits (Pasha Bank / Oracle BI, and a DBeaver Temurin-25 report).
2. **Catalog scoping for BI tools** — `compatibilityMode=oracle` / `catalogFilterEnabled`, which pin a connection to one catalog for clients that assume two-part `schema.table` names.

## Changes

- **`user-guide/driver/arrow-flight-jdbc-driver.mdx`**
  - New **Java Version Requirements** section: flag matrix (none on JDK 8–15 → `--add-opens=java.base/java.nio=ALL-UNNAMED` on 16–23 → both flags incl. `--sun-misc-unsafe-memory-access=allow` on 24+), the errors seen when flags are missing, the rationale (JEP 396/403 for `java.nio` encapsulation, JEP 498 for `sun.misc.Unsafe`), and how to pass flags (`java -jar`, `JDK_JAVA_OPTIONS`, application-server Java options).
  - New **Catalog Scoping for BI Tools** section (driver ≥ 19.0.0-iomete.3): parameter table (`compatibilityMode`, `catalogFilterEnabled`, `schema`) and URL examples for pinning Oracle-style clients to a single catalog against IOMETE's three-part `catalog.schema.table` hierarchy.
  - Refreshed driver description; Arrow doc links pinned to the 19.0 release.
- **`docs/integrations/dbtools/dbeaver.md`** — new **Java Version Requirements** section with the `dbeaver.ini` `-vmargs` recipe and the "auto-update silently swapped the bundled JRE" gotcha, cross-linked to the driver guide.

## Verified

- Flag boundaries confirmed against a client-only repro (JDK 11 PASS / 17 FAIL for `--add-opens`) and OpenJDK JEPs (498 → JDK 24 `warn`, JDK 26 `deny`; `--sun-misc-unsafe-memory-access` valid only on JDK 24+).
- `npm run build` passes (no MDX errors, no broken links/anchors).

Refs:
- [COM-767](https://linear.app/iomete/issue/COM-767)
- [COM-476](https://linear.app/iomete/issue/COM-476) (Pasha umbrella)
- [COM-674](https://linear.app/iomete/issue/COM-674) (error enrichment)
- [COM-653](https://linear.app/iomete/issue/COM-653) (error propagation)


### DBeaver:

<img width="890" height="1037" alt="image" src="https://github.com/user-attachments/assets/28b6d32c-a929-457c-8795-d4ce50109698" />

### Arrow:

<img width="807" height="1209" alt="image" src="https://github.com/user-attachments/assets/426cdd3f-159d-468b-91a2-54ca5e4f230b" />

<img width="794" height="1954" alt="image" src="https://github.com/user-attachments/assets/62dea949-eb80-4ab7-8eb9-5ee9fb526ff2" />

