### PR TITLE
GRO-898: Add spacing below blog card images

### DIFF
--- a/src/theme/BlogListPage/card/index.tsx
+++ b/src/theme/BlogListPage/card/index.tsx
@@ -27,7 +27,12 @@ function Card({ frontMatter, metadata, isFeatured }: ContentExtended) {
             decoding="async"
           />
         </div>
-        <div className={`card__body p-0 mt-1 flex flex-col gap-1 min-w-[50%]`}>
+        <div
+          className={clsx(
+            "card__body p-0 mt-1 flex flex-col gap-1 min-w-[50%]",
+            isFeatured && "md:mt-0"
+          )}
+        >
           <div className="flex items-center gap-4">
             <CardDate date={metadata.date} />
             <CardTags tags={frontMatter.tags2} />

--- a/src/theme/BlogListPage/card/index.tsx
+++ b/src/theme/BlogListPage/card/index.tsx
@@ -27,7 +27,7 @@ function Card({ frontMatter, metadata, isFeatured }: ContentExtended) {
             decoding="async"
           />
         </div>
-        <div className={`card__body p-0 flex flex-col gap-1 min-w-[50%]`}>
+        <div className={`card__body p-0 mt-1 flex flex-col gap-1 min-w-[50%]`}>
           <div className="flex items-center gap-4">
             <CardDate date={metadata.date} />
             <CardTags tags={frontMatter.tags2} />


### PR DESCRIPTION
## Summary
- Adds a small top margin between blog card thumbnails and the date/tag metadata row.
- Keeps the change scoped to the blog list card component.
- Links this PR to [GRO-898](https://linear.app/iomete/issue/GRO-898/help-with-iom-blog).

## Screenshots
Before:
<img width="817" height="459" alt="image" src="https://github.com/user-attachments/assets/0ac0edba-6904-43eb-b104-c49a021efdf2" />

After:
<img width="743" height="360" alt="image" src="https://github.com/user-attachments/assets/375dde3d-3d53-4bbb-b06e-e2ce9fc89d98" />

## Testing
- `git diff --check -- src/theme/BlogListPage/card/index.tsx`
- `npm run build -- --no-minify`
- Local visual check on `http://127.0.0.1:3030/resources/blog` using Chrome/Playwright.
