### PR TITLE
fix(data-security-api): correct endpoint paths and align page with the API

### DIFF
--- a/user-guide/data-security/data-security-api.md
+++ b/user-guide/data-security/data-security-api.md
@@ -1,7 +1,10 @@
 ---
 title: Data Security API
 sidebar_label: Data Security API
-description: Data Security API allows developers to manage data access, masking, and filtering efficiently.
+description: Manage IOMETE access, masking, filtering and tag-based policies programmatically. Covers endpoints, request bodies, the required admin role and error handling.
+last_update:
+  date: 07/30/2026
+  author: Mateus Aubin
 ---
 
 import FAQSection from '@site/src/components/FAQSection';

--- a/user-guide/data-security/data-security-api.md
+++ b/user-guide/data-security/data-security-api.md
@@ -4,6 +4,8 @@ sidebar_label: Data Security API
 description: Data Security API allows developers to manage data access, masking, and filtering efficiently.
 ---
 
+import FAQSection from '@site/src/components/FAQSection';
+
 ## Introduction
 
 Data Security API allows developers to manage data access, masking, and filtering efficiently.
@@ -14,7 +16,7 @@ The API also supports masking sensitive data, defining row-level filters, and im
 
 ## Authentication
 
-To interact with the IOMETE Data Security API, users need to create an access token and include it in the headers of API requests.
+To interact with the IOMETE Data Security API, you create an access token and include it in the headers of your API requests.
 
 Header Example:
 
@@ -22,11 +24,19 @@ Header Example:
 X-API-Token: <Your-API-Token>
 ```
 
-Tokens can be generated in the IOMETE UI under the settings. Please refer to [this documentation](../access-tokens/personal) for more info.
+You generate tokens in the IOMETE UI under the settings. See [Personal Access Tokens](../access-tokens/personal.md) for details.
+
+### Required Admin Role
+
+Every endpoint on this page requires the **Data Security and Audit Manager** admin role. A valid token alone is not enough. If the user or service account behind the token does not hold this role, the request fails with `403 Forbidden`.
+
+If you hold the **Read-Only Admin** role instead, you get read access only. You can call the `GET` endpoints to list and read policies, but not create, update, or delete them.
+
+See [Admin Roles](../iam/admin-roles.md) to review and assign roles.
 
 ## Access Control API
 
-The Access Control API allows developers to manage user access to databases, tables, and columns programmatically.
+The Access Control API lets you manage user access to databases, tables, and columns programmatically. It is the API equivalent of the [Access Policy](./access-policy.mdx) screens in the console.
 
 You can use this API to:
 
@@ -34,14 +44,15 @@ You can use this API to:
 - Define granular permissions on databases, tables, or even specific columns.
 - Automate access control to ensure secure and compliant data usage.
 
-### Creating Access Policy
+### Creating an Access Policy
 
 HTTP Method: `POST`  
-Endpoint: `https://example.com/api/v1/data-security/access/policy`
+Endpoint: `https://example.com/api/v1/admin/data-security/access/policy`
 
 **Request Body Parameters**
 
 - **isEnabled** (`boolean`): Enable or disable the access policy.
+- **priority** (`string`): Optional. Can be `NORMAL` or `OVERRIDE`; defaults to `NORMAL`. An `OVERRIDE` policy takes precedence over `NORMAL` ones.
 - **name** (`string`): A unique name for the access policy. Allows alpha-numeric characters and the hyphen `-`.
 - **description** (`string`): Optional description of the policy.
 - **validityPeriod** (`object`): Optional. Defines the start and end time of the policy. Includes:
@@ -52,13 +63,20 @@ Endpoint: `https://example.com/api/v1/data-security/access/policy`
   - **databases** (`array`): List of databases (e.g., `["spark_catalog.default"]`). Catalog name should be specified as in the example.
   - **tables** (`array`): List of tables (e.g., `["demo_table"]` or `["*"]` - for all tables).
   - **columns** (`array`): List of columns (e.g., `["*"]` for all columns).
-- **databaseInclusionType** (`string`): Can be `INCLUDE` or `EXCLUDE`.
-- **tableInclusionType** (`string`): Can be `INCLUDE` or `EXCLUDE`.
-- **columnInclusionType** (`string`): Can be `INCLUDE` or `EXCLUDE`.
+  - **databasesInclusionType** (`string`): Optional. Can be `INCLUDE` or `EXCLUDE`; defaults to `INCLUDE`.
+  - **tablesInclusionType** (`string`): Optional. Can be `INCLUDE` or `EXCLUDE`; defaults to `INCLUDE`.
+  - **columnsInclusionType** (`string`): Optional. Can be `INCLUDE` or `EXCLUDE`; defaults to `INCLUDE`.
 - **allowPolicyItems** (`array`): Defines users or groups with access and the access types. Each policy item includes:
   - **groups** (`array`): List of groups (e.g., `["admin_group"]`).
   - **users** (`array`): List of users (e.g., `["admin"]`).
-  - **accesses** (`array`): List of access types (e.g., `["SELECT"]`). Possible values: `ALL`, `SELECT`, `UPDATE`, `CREATE`, `DROP`, `ALTER`, `WRITE`.
+  - **roles** (`array`): List of role names granted this access (e.g., `["analysts"]`). These are policy subjects alongside users and groups, unrelated to the admin roles in [Required Admin Role](#required-admin-role).
+  - **accesses** (`array`): List of access types (e.g., `["SELECT"]`). Possible values: `ALL`, `SELECT`, `INSERT`, `UPDATE`, `DELETE`, `CREATE`, `DROP`, `ALTER`, `READ`, `WRITE`, `REFRESH`, `CREATE_DATABASE`, `DROP_DATABASE`, `ALTER_DATABASE`.
+
+:::warning Field names must match exactly
+
+The API ignores unrecognized fields instead of rejecting them. If you misspell an inclusion type (for example `databaseInclusionType` instead of `databasesInclusionType`), the API drops your value and falls back to `INCLUDE`. The request still succeeds with a `201`, so an `EXCLUDE` rule written this way silently becomes an `INCLUDE` rule. Always check the response body to confirm the stored values.
+
+:::
 
 ### Example Request
 
@@ -67,7 +85,7 @@ In this example, we create a policy that grants `SELECT` access to the `admin` u
 Curl Example:
 
 ```bash showLineNumbers
-curl -X POST https://example.com/api/v1/data-security/access/policy \
+curl -X POST https://example.com/api/v1/admin/data-security/access/policy \
 -H "Content-Type: application/json" \
 -H "X-API-Token: <Your-API-Token>" \
 -d '{
@@ -84,9 +102,9 @@ curl -X POST https://example.com/api/v1/data-security/access/policy \
       "databases": ["spark_catalog.default"],
       "tables": ["demo_table"],
       "columns": ["*"],
-      "databaseInclusionType": "INCLUDE",
-      "tableInclusionType": "INCLUDE",
-      "columnInclusionType": "INCLUDE"
+      "databasesInclusionType": "INCLUDE",
+      "tablesInclusionType": "INCLUDE",
+      "columnsInclusionType": "INCLUDE"
     }
   ],
   "allowPolicyItems": [
@@ -106,10 +124,10 @@ A successful request returns a status code of 201 and a JSON response with the d
 
 ```json showLineNumbers
 {
-  "id": "12345",
+  "id": 12345,
   "isEnabled": true,
   "priority": "NORMAL",
-  "name": "access-to-resource-api-example",
+  "name": "access-to-demo-api-example",
   "validityPeriod": {
     "startTime": "2024/10/10 00:00:00",
     "endTime": "2024/10/30 00:00:00",
@@ -118,8 +136,11 @@ A successful request returns a status code of 201 and a JSON response with the d
   "resources": [
     {
       "databases": ["spark_catalog.default"],
+      "databasesInclusionType": "INCLUDE",
       "tables": ["demo_table"],
-      "columns": ["*"]
+      "tablesInclusionType": "INCLUDE",
+      "columns": ["*"],
+      "columnsInclusionType": "INCLUDE"
     }
   ],
   "allowPolicyItems": [
@@ -131,30 +152,30 @@ A successful request returns a status code of 201 and a JSON response with the d
 }
 ```
 
-### Delete Access Policy API
+### Deleting an Access Policy
 
-To delete an access policy, you can use the following `DELETE` request. You need to provide the unique `policy_id` in the URL, which you get from the policy creation or listing.
+To delete an access policy, use the following `DELETE` request. Provide the unique `policy_id` in the URL, which you get from the policy creation or listing.
 
 ```bash showLineNumbers
-curl -X DELETE https://example.com/api/v1/data-security/access/policy/<policy_id> \
+curl -X DELETE https://example.com/api/v1/admin/data-security/access/policy/<policy_id> \
 -H "X-API-Token: <Your-API-Token>"
 ```
 
-### List Access Policies
+### Listing Access Policies
 
-To list all access policies, you can use the following `GET` request.
+To list all access policies, use the following `GET` request.
 
 ```bash showLineNumbers
-curl -X GET https://example.com/api/v1/data-security/access/policy \
+curl -X GET https://example.com/api/v1/admin/data-security/access/policy \
 -H "X-API-Token: <Your-API-Token>"
 ```
 
-### Update Access Policy
+### Updating an Access Policy
 
-Updating policy is similar to creation but requires the `policy_id` in the URL. You can modify the policy details in the request body.
+Updating a policy is similar to creating one, but requires the `policy_id` in the URL. You modify the policy details in the request body.
 
 ```bash showLineNumbers
-curl -X PUT https://example.com/api/v1/data-security/access/policy/123 \
+curl -X PUT https://example.com/api/v1/admin/data-security/access/policy/123 \
 -H "Content-Type: application/json" \
 -H "X-API-Token: <Your-API-Token>" \
 -d '{
@@ -167,9 +188,9 @@ curl -X PUT https://example.com/api/v1/data-security/access/policy/123 \
       "databases": ["spark_catalog.default"],
       "tables": ["demo_table"],
       "columns": ["*"],
-      "databaseInclusionType": "INCLUDE",
-      "tableInclusionType": "INCLUDE",
-      "columnInclusionType": "INCLUDE"
+      "databasesInclusionType": "INCLUDE",
+      "tablesInclusionType": "INCLUDE",
+      "columnsInclusionType": "INCLUDE"
     }
   ],
   "allowPolicyItems": [
@@ -183,27 +204,29 @@ curl -X PUT https://example.com/api/v1/data-security/access/policy/123 \
 
 ## Other Features
 
+The same authentication, admin role and error handling rules apply to the other data security APIs. Each one follows the request and response shape shown above, so the sections below list only the base endpoint and point to the corresponding console documentation.
+
 ### Data Masking API
 
-The Data Masking API allows masking of sensitive data at the column level. This feature is useful for protecting sensitive information by showing only a part or transformed version of the data to specific users.
+The Data Masking API masks sensitive data at the column level, showing only part of the data, or a transformed version of it, to specific users. See [Data Masking](./data-masking.mdx).
 
 **Example Use Case**: Masking credit card numbers or personal identifiers.  
-**Base Endpoint**: `https://example.com/api/v1/data-security/mask/policy`
+**Base Endpoint**: `https://example.com/api/v1/admin/data-security/mask/policy`
 
-### Row-level Filters API
+### Row-Level Filters API
 
-The Row-level Filters API enables defining row-level access policies, allowing users to access only specific rows in a table based on conditions.
+The Row-Level Filters API defines row-level access policies, so users see only the rows in a table that match your conditions. See [Row-Level Filter](./row-level-filter.mdx).
 
 **Example Use Case**: Restricting access to sales data from specific regions based on user roles.  
-**Base Endpoint**: `https://example.com/api/v1/data-security/filter/policy`
+**Base Endpoint**: `https://example.com/api/v1/admin/data-security/filter/policy`
 
-### Tag-based Access Control API
+### Tag-Based Access Control API
 
-With Tag-based Access Control, you can apply access policies based on metadata tags assigned to data resources. This is useful for managing access at scale by grouping data under tags.
+With tag-based access control, you apply access policies based on metadata tags assigned to data resources. This manages access at scale by grouping data under tags. See [Tag-Based Access Policy](./tag-based-access-policy.mdx) and [Tag-Based Data Masking](./tag-based-data-masking.mdx).
 
 **Example Use Case**: Tagging sensitive financial data and enforcing stricter access controls based on tags.  
-**Base Endpoint**: `https://example.com/api/v1/data-security/tag/access/policy`  
-**Base Endpoint for Tag based Masking policies**: `https://example.com/api/v1/data-security/tag/mask/policy`
+**Base Endpoint**: `https://example.com/api/v1/admin/data-security/tag/access/policy`  
+**Base Endpoint for tag-based masking policies**: `https://example.com/api/v1/admin/data-security/tag/mask/policy`
 
 ## Error Handling
 
@@ -211,12 +234,13 @@ The IOMETE Data Security API uses standard HTTP error codes to indicate request 
 
 **400 Bad Request**: The request body is malformed or missing required fields.  
 **401 Unauthorized**: The API token is invalid or missing.  
-**403 Forbidden**: The user does not have permission to perform the requested action.  
+**403 Forbidden**: The token is valid, but the user or service account behind it lacks the required admin role. See [Required Admin Role](#required-admin-role).  
+**404 Not Found**: The endpoint path is wrong. Check that it includes the `/admin/` segment.  
 **500 Internal Server Error**: A server error occurred.
 
-import FAQSection from '@site/src/components/FAQSection';
-
 ## FAQs
+
+Common questions about managing policies through the API.
 
 <FAQSection faqs={[
   {
@@ -225,6 +249,6 @@ import FAQSection from '@site/src/components/FAQSection';
   },
   {
     question: "What happens if conflicting policies exist?",
-    answer: "The policy with higher priority (HIGH) will override policies with NORMAL priority."
+    answer: "A policy with OVERRIDE priority takes precedence over policies with NORMAL priority."
   }
 ]} />

--- a/user-guide/data-security/data-security-api.md
+++ b/user-guide/data-security/data-security-api.md
@@ -204,7 +204,7 @@ curl -X PUT https://example.com/api/v1/admin/data-security/access/policy/123 \
 
 ## Other Features
 
-The same authentication, admin role and error handling rules apply to the other data security APIs. Each one follows the request and response shape shown above, so the sections below list only the base endpoint and point to the corresponding console documentation.
+The same authentication, admin role and error handling rules apply to the other data security APIs. Each policy type has its own request and response format, so the sections below list only the base endpoint and point to the corresponding console documentation.
 
 ### Data Masking API
 


### PR DESCRIPTION
## Why

Three defects on the public [Data Security API](https://iomete.com/resources/user-guide/data-security/data-security-api) page. One fails loudly, one fails open.

1. **Every endpoint omitted `/admin/`.** Following the page verbatim returns the nginx default 404. Backend moved to `/api/v1/admin/data-security` on 2025-02-02 (`fb5a567`); page added 2024-10-10, never updated.
2. **Inclusion-type fields were singular, the API expects plural.** `AccessPolicyView` is `@JsonIgnoreProperties(ignoreUnknown = true)`, so `databaseInclusionType` was dropped rather than rejected and fell back to its `INCLUDE` default. A reader writing an `EXCLUDE` rule got a `201` and a policy that grants access instead. Hence the added warning, not just a rename.
3. **The required admin role was undocumented.** Every method needs Data Security and Audit Manager. The page listed `403` with no way to know what triggers it.

Surfaced by [COM-127](https://linear.app/iomete/issue/COM-127), whose customer advisory points at this page.

## What changed

Single file, `user-guide/data-security/data-security-api.md`.

- 9 paths corrected to `/admin/`.
- Inclusion types to plural, moved inside `resources`, documented as optional with real defaults.
- New `:::warning` on the silent unknown-field coercion.
- New `### Required Admin Role` section: required role, Read-Only Admin GET-only exemption.
- `priority` and `roles` documented; FAQ's non-existent `HIGH` to `OVERRIDE`; `accesses` enum 7 to 14 values.
- Response example: added missing inclusion types, `"id"` string to number. Error Handling: added `404`, `403` now names its cause.
- `Other Features` no longer claims the mask, filter and tag APIs share the access-policy shape. They do not.
- Frontmatter: added `last_update`, replaced the description (it was a verbatim copy of the first body sentence).
- Cleanups while open: gerund headings, second person, Title Case, filler removed, import hoisted, sibling pages linked.

<img width="973" height="310" alt="Rendered Required Admin Role section: every endpoint requires the Data Security and Audit Manager admin role, a valid token alone is not enough and returns 403 Forbidden; Read-Only Admin gets read access to the GET endpoints only; link to Admin Roles" src="https://github.com/user-attachments/assets/5a0f9ebe-25cc-436b-aa55-734bbf8081f5" />

<img width="961" height="213" alt="Rendered warning admonition titled Field Names Must Match Exactly, explaining that the API ignores unrecognized fields, so databaseInclusionType instead of databasesInclusionType is dropped and falls back to INCLUDE, and an EXCLUDE rule silently becomes an INCLUDE rule with a 201" src="https://github.com/user-attachments/assets/132e7358-c5d0-47d0-b647-c4c3ca6f16ae" />

## Decisions

| Decision | Rationale |
| -- | -- |
| Documented runtime behaviour, not the schema | `openapi/iam.json` marks `name`, `priority` and all 3 inclusion types `required`; none is enforced (POST without them gives `201`). Enum *values* are enforced (`HIGH` gives `400`). Spec/runtime gap is a backend defect, in the ticket, not fixed here. |
| Rename **plus** a warning | The rename fixes copy-paste. Anyone adapting an older snippet still hits the invisible coercion. |
| Scoped to the access policy APIs | The mask, filter and tag bodies each differ from the access policy and were not verified here. Tracked in [PLA-695](https://linear.app/iomete/issue/PLA-695). |
| Rejected a review "blocker" | Review flagged "Read-Only Admin is not a real role", from the stale `iam/admin-roles.md` ([PLA-691](https://linear.app/iomete/issue/PLA-691)). The live API returns `READ_ONLY_ADMIN`. |

## Testing

**PASS on all layers.** Verified against `dev.iomete.cloud` (`iomete-dev-eks`), 2026-07-29, one token at three privilege levels.

| Layer | Evidence |
| -- | -- |
| Path routing | `access/policy`: no token `401`, invalid `401`, valid without role `403`, valid with role `200`. The documented non-`/admin/` path gives nginx `404` at **every** level. Holds for all 5 paths, all methods. |
| Gateway / contract | Live `cm/iom-gateway-config` has one match, `~*^/api/v[\d]/admin/data-security`, and no non-`/admin/` route on any branch. `openapi/iam.json`: 12 `data-security` paths, all `/admin/`. |
| Fail-open | `databaseInclusionType=EXCLUDE` gives `201`, stored `INCLUDE` (2997). Plural gives stored `EXCLUDE` (2998). |
| Role gate | Zero-permission token gives `403` on all 5 paths, message names `'Data Security and Audit Manager'`. Read-Only Admin: GET all 5 give `200` (33/28/22/3/3), POST/PUT/DELETE give `403`. |
| Build | Exit 0. 5 new links and the `#required-admin-role` anchor verified in rendered HTML. |

<details><summary>Caveats</summary>

- Policies 2995-2999 created during verification, all deleted (`204`), count back to 33. Role rounds were read-only.
- `PUT` confirmed routed and role-gated; body not round-tripped. Shape is the proven `POST` plus `id`.
- The 14 `accesses` values come from `AccessType` and the served spec, not from posting each. Enum enforcement proven by `HIGH` giving `400`.
- The four other policy bodies were read from source only, not exercised on dev.
- The dev server cannot verify content: client-rendered, same SPA shell with `200` for any path. All content checks ran against a production build.
- `onBrokenMarkdownLinks` is `"warn"`, so broken relative `.md` links do not fail CI. New links verified by grepping rendered hrefs.

</details>

## References

issue: [PLA-682](https://linear.app/iomete/issue/PLA-682)
follow-up: [PLA-695](https://linear.app/iomete/issue/PLA-695) — mask, filter and tag policy bodies, out of scope here
related: [PLA-691](https://linear.app/iomete/issue/PLA-691) — Admin Roles page omits Read-Only Admin, which this page now links to
related: [COM-127](https://linear.app/iomete/issue/COM-127) — surfaced this
