### PR TITLE
docs(release-notes): add 3.18.0 Vault auth-token cache TTL improvement (PLA-689)

### DIFF
--- a/docs/deployment/on-prem/release-notes/index.md
+++ b/docs/deployment/on-prem/release-notes/index.md
@@ -28,7 +28,7 @@ import { Release, NewFeatures, Improvements, BugFixes, ReleaseDescription, Depre
     - **Domain-Scoped Volume & Node Type APIs**: The domain-scoped `GET` endpoints for volumes and node types are now documented in the OpenAPI spec. The API allows non-admin users with access to a domain to list and view node types and volumes without needing an admin role.
     - **Scoped Service Account Selection**: The "Run as user" dropdown now shows service accounts the current user can manage instead of every service account in the domain.
     - **Comprehensive API Audit Logging**: All API requests are now logged to `platform_event_logs`, capturing user, timestamp, path, HTTP method, and success status. Health, metrics, and internal service-check endpoints are excluded.
-    - **Vault Secret Caching**: Increased the default cache TTL for Vault authentication tokens from 30 seconds to 60 seconds. IOMETE re-authenticates to the configured Vault server less often when resolving secrets, reducing auth token generation load, with no change to secret-resolution behavior.
+    - **Vault Auth Token Caching**: Increased the default cache TTL for Vault authentication tokens from 30 seconds to 60 seconds. IOMETE re-authenticates to the configured Vault server less often when resolving secrets, reducing auth token generation load, with no change to secret-resolution behavior.
   </Improvements>
 
   <BugFixes>

--- a/docs/deployment/on-prem/release-notes/index.md
+++ b/docs/deployment/on-prem/release-notes/index.md
@@ -28,7 +28,7 @@ import { Release, NewFeatures, Improvements, BugFixes, ReleaseDescription, Depre
     - **Domain-Scoped Volume & Node Type APIs**: The domain-scoped `GET` endpoints for volumes and node types are now documented in the OpenAPI spec. The API allows non-admin users with access to a domain to list and view node types and volumes without needing an admin role.
     - **Scoped Service Account Selection**: The "Run as user" dropdown now shows service accounts the current user can manage instead of every service account in the domain.
     - **Comprehensive API Audit Logging**: All API requests are now logged to `platform_event_logs`, capturing user, timestamp, path, HTTP method, and success status. Health, metrics, and internal service-check endpoints are excluded.
-    - **Vault Auth Token Caching**: Increased the default cache TTL for Vault authentication tokens from 30 seconds to 60 seconds. IOMETE re-authenticates to the configured Vault server less often when resolving secrets, reducing auth token generation load, with no change to secret-resolution behavior.
+    - **Vault Authentication Token Caching**: Increased the default cache TTL for Vault authentication tokens from 30 seconds to 60 seconds. IOMETE re-authenticates to the configured Vault server less often when resolving secrets, reducing auth token generation load, with no change to secret-resolution behavior.
   </Improvements>
 
   <BugFixes>

--- a/docs/deployment/on-prem/release-notes/index.md
+++ b/docs/deployment/on-prem/release-notes/index.md
@@ -28,6 +28,7 @@ import { Release, NewFeatures, Improvements, BugFixes, ReleaseDescription, Depre
     - **Domain-Scoped Volume & Node Type APIs**: The domain-scoped `GET` endpoints for volumes and node types are now documented in the OpenAPI spec. The API allows non-admin users with access to a domain to list and view node types and volumes without needing an admin role.
     - **Scoped Service Account Selection**: The "Run as user" dropdown now shows service accounts the current user can manage instead of every service account in the domain.
     - **Comprehensive API Audit Logging**: All API requests are now logged to `platform_event_logs`, capturing user, timestamp, path, HTTP method, and success status. Health, metrics, and internal service-check endpoints are excluded.
+    - **Vault Secret Caching**: Increased the default cache TTL for Vault authentication tokens from 30 seconds to 60 seconds. IOMETE re-authenticates to the configured Vault server less often when resolving secrets, reducing auth token generation load, with no change to secret-resolution behavior.
   </Improvements>
 
   <BugFixes>


### PR DESCRIPTION
## Summary
Adds a 3.18.0 release-note entry (under **Improvements**) for the Vault auth-token cache TTL change (PLA-689 / PLA-669): the default cache TTL was increased from 30s to 60s, so IOMETE re-authenticates to the configured Vault server less often when resolving secrets — reducing auth-token-generation load, with no change to secret-resolution behavior.

## Change
- `docs/deployment/on-prem/release-notes/index.md` — one line appended to the 3.18.0 `<Improvements>` block. No other content touched.

## Validation
- Single-line docs change; renders as a standard `<Improvements>` bullet.
- Wording kept customer-facing; not described as Helm-configurable (it is an internal `application.yaml` `vault-auth-tokens` cache TTL value).

## Links
- Ticket: PLA-689 (cherry-pick of PLA-669) — kotlin-monorepo PR #3382 / release_3.18.x PR #3389
